### PR TITLE
[draft] Set up edge function to lookup storage location

### DIFF
--- a/components/datasets/store.js
+++ b/components/datasets/store.js
@@ -8,8 +8,8 @@ const DEFAULT_DISPLAY_TIMES = {
   HISTORICAL: { year: 1950, month: 1, day: 1 },
   PROJECTED: { year: 2015, month: 1, day: 1 },
 }
-const getInitialDatasets = (data) => {
-  return data.datasets.reduce((accum, dataset) => {
+const getInitialDatasets = (datasets) => {
+  return datasets.reduce((accum, dataset) => {
     accum[dataset.name] = {
       name: dataset.name,
       source: dataset.uri,
@@ -28,8 +28,8 @@ const getInitialDatasets = (data) => {
   }, {})
 }
 
-const getInitialFilters = (data) => {
-  return data.datasets.reduce(
+const getInitialFilters = (datasets) => {
+  return datasets.reduce(
     (accum, ds) => {
       accum.experiment[ds.experiment] = accum.experiment[ds.experiment] || false
       accum.gcm[ds.gcm] = true
@@ -60,15 +60,10 @@ export const useDatasetsStore = create((set, get) => ({
       set({ loading: get().loading.filter((v) => v !== key) })
     }
   },
-  fetchDatasets: async () => {
-    const result = await fetch(
-      'https://cmip6downscaling.blob.core.windows.net/scratch/cmip6-web-test-8/catalog.json'
-    )
-    const data = await result.json()
-
+  populateDatasets: (catalog) => {
     set({
-      datasets: getInitialDatasets(data),
-      filters: getInitialFilters(data),
+      datasets: getInitialDatasets(catalog),
+      filters: getInitialFilters(catalog),
     })
   },
   setDisplayTime: (value) => set({ displayTime: value }),

--- a/components/sections/query/query-section.js
+++ b/components/sections/query/query-section.js
@@ -207,18 +207,9 @@ const Inner = ({ sx }) => {
 }
 
 const QuerySection = ({ sx }) => {
-  const datasets = useDatasetsStore((state) => state.datasets)
-  const fetchDatasets = useDatasetsStore((state) => state.fetchDatasets)
-
-  useEffect(() => {
-    if (!datasets) {
-      fetchDatasets()
-    }
-  }, [])
-
   return (
     <Section sx={sx.heading} label='Datasets' defaultExpanded>
-      {datasets ? <Inner sx={sx} /> : 'Loading...'}
+      <Inner sx={sx} />
     </Section>
   )
 }

--- a/pages/[storage].js
+++ b/pages/[storage].js
@@ -1,0 +1,32 @@
+import Index from '../tool/index.js'
+
+const CATALOG_MAP = {
+  us: 'https://cmip6downscaling.blob.core.windows.net/scratch/cmip6-web-test-8/catalog.json',
+  eu: 'https://cmip6downscaling.blob.core.windows.net/scratch/cmip6-web-test-8/catalog.json',
+}
+
+export default Index
+
+export async function getStaticProps({ params }) {
+  const catalogLocation = CATALOG_MAP[params.storage]
+  const res = await fetch(catalogLocation)
+  const data = await res.json()
+
+  // For illustration purposes only
+  const catalog = data.datasets.map((d) => ({
+    ...d,
+    name: `${params.storage} ${d.name}`,
+  }))
+
+  return { props: { catalog } }
+}
+
+export function getStaticPaths() {
+  const paths = Object.keys(CATALOG_MAP).map((storage) => ({
+    params: { storage },
+  }))
+
+  // We'll pre-render only these paths at build time.
+  // { fallback: false } means other routes should 404.
+  return { paths, fallback: false }
+}

--- a/pages/_middleware.js
+++ b/pages/_middleware.js
@@ -1,0 +1,79 @@
+import { NextResponse } from 'next/server'
+
+const STORAGE = {
+  us: {
+    US: true,
+  },
+  eu: {
+    AT: true,
+    BE: true,
+    BG: true,
+    HR: true,
+    CY: true,
+    CZ: true,
+    DK: true,
+    EE: true,
+    FI: true,
+    FR: true,
+    DE: true,
+    GR: true,
+    HU: true,
+    IE: true,
+    IT: true,
+    LV: true,
+    LT: true,
+    LU: true,
+    MT: true,
+    NL: true,
+    PL: true,
+    PT: true,
+    RO: true,
+    SK: true,
+    SI: true,
+    ES: true,
+    SE: true,
+    AL: true,
+    AD: true,
+    AM: true,
+    BY: true,
+    BA: true,
+    FO: true,
+    GE: true,
+    GI: true,
+    IS: true,
+    IM: true,
+    XK: true,
+    LI: true,
+    MK: true,
+    MD: true,
+    MC: true,
+    ME: true,
+    NO: true,
+    RU: true,
+    SM: true,
+    RS: true,
+    CH: true,
+    TR: true,
+    UA: true,
+    GB: true,
+    VA: true,
+  },
+}
+
+export default function middleware(req) {
+  const country = req.geo.country?.toUpperCase() || 'US'
+  console.log('geo', {
+    country,
+    rawCountry: req.geo.country?.toUpperCase(),
+  })
+  const storage = STORAGE.us[country] ? 'us' : 'eu'
+
+  // Unless already on an explicit `/{storage}` route, rewrite to country-specific
+  const match = req.nextUrl.pathname.match(/(?<=\/)\w{2}$/)
+
+  if (!match || !STORAGE[match[0]]) {
+    console.log('rewriting', storage)
+    req.nextUrl.pathname = `/${storage}`
+    return NextResponse.rewrite(req.nextUrl)
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,3 +1,0 @@
-import Index from '../tool/index.js'
-
-export default Index

--- a/tool/index.js
+++ b/tool/index.js
@@ -1,6 +1,6 @@
 import { Box, Container } from 'theme-ui'
 import { Group } from '@carbonplan/components'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import Header from '../components/header'
 import ControlPanel from '../components/control-panel'
@@ -13,6 +13,7 @@ import {
 import Map from '../components/map'
 import ControlPanelDivider from '../components/control-panel-divider'
 import { useRegionStore } from '../components/region'
+import { useDatasetsStore } from '../components/datasets'
 
 const sx = {
   heading: {
@@ -34,9 +35,17 @@ const sx = {
   },
 }
 
-const Tool = () => {
+const Tool = ({ catalog }) => {
   const [loading, setLoading] = useState(false)
   const closeRegionPicker = useRegionStore((state) => state.closeRegionPicker)
+  const datasets = useDatasetsStore((state) => state.datasets)
+  const populateDatasets = useDatasetsStore((state) => state.populateDatasets)
+
+  useEffect(() => {
+    if (!datasets) {
+      populateDatasets(catalog)
+    }
+  }, [])
 
   return (
     <>


### PR DESCRIPTION
This PR sets up a simple edge function to inspect the geo IP and rewrite route to indicate which catalog to use. Right now, there are two different storage options, `eu` and `us` (which are actually both referencing the same catalog with datasets stored in Europe). For illustration purposes, the datasets are renamed based on which storage is being used.

Notes:
- The logic that determines which storage location to use is really simple and based on the request `country` compared against a hardcoded list of countries for each location. Open to suggestions for improvements here, perhaps based on actual geoIP?
- The storage location can be overwritten explicitly (e.g. by navigating to `/us`). We'll need to do some thinking about a natural way to hook into this option in the UI.
- This also assumes that there are distinct catalogs per location, but the implementation could be adjusted if this isn't practical. One upside of making this assumption is that by making each location self-describing, we avoid any complications or complex validations from the risk of buckets getting out of sync.

cc @jhamman @freeman-lab 