### PR TITLE
Load ERA5 pyramids

### DIFF
--- a/components/datasets/store.js
+++ b/components/datasets/store.js
@@ -61,7 +61,7 @@ export const useDatasetsStore = create((set, get) => ({
   updatingTime: false,
   fetchDatasets: async () => {
     const result = await fetch(
-      'https://cmip6downscaling.blob.core.windows.net/flow-outputs/results/pyramids/cmip6/cmip6-pyramids-catalog-web.json'
+      'https://cmip6downscaling.blob.core.windows.net/flow-outputs/results/pyramids/era5/era5-pyramids-catalog-web.json'
     )
     const data = await result.json()
     const datasets = getInitialDatasets(data)

--- a/components/datasets/store.js
+++ b/components/datasets/store.js
@@ -5,7 +5,7 @@ import DateStrings from './date-strings'
 import { areSiblings, getDatasetDisplay, getFiltersCallback } from './utils'
 
 const DEFAULT_DISPLAY_TIMES = {
-  HISTORICAL: { year: 1950, month: 1, day: 1 },
+  HISTORICAL: { year: 1980, month: 1, day: 1 },
   PROJECTED: { year: 2015, month: 1, day: 1 },
 }
 
@@ -17,7 +17,7 @@ const getInitialDatasets = (data) => {
       variable: dataset.variable_id,
       gcm: dataset.source_id,
       method: dataset.method,
-      experiment: dataset.experiment_id,
+      experiment: dataset.experiment_id ?? 'historical',
       timescale: dataset.timescale,
       original_dataset_uris: dataset.original_dataset_uris,
       institution: dataset.institution_id,
@@ -38,7 +38,7 @@ const getInitialFilters = (datasets) => {
   return Object.keys(datasets).reduce(
     (accum, name) => {
       const ds = datasets[name]
-      accum.experiment[ds.experiment] = accum.experiment[ds.experiment] ?? true
+      accum.experiment[ds.experiment] = accum.experiment[ds.experiment] ?? false
       accum.gcm[ds.gcm] = true
       accum.method[ds.method] = true
       return accum
@@ -46,7 +46,7 @@ const getInitialFilters = (datasets) => {
     {
       variable: 'tasmax',
       timescale: 'year',
-      experiment: { historical: false },
+      experiment: { historical: true },
       gcm: {},
       method: {},
     }

--- a/components/sections/time/sliders.js
+++ b/components/sections/time/sliders.js
@@ -89,7 +89,7 @@ const TimeSlider = ({
 }
 
 const YEAR_RANGES = {
-  HISTORICAL: [1950, 2014],
+  HISTORICAL: [1980, 2020],
   PROJECTED: [2015, 2100],
 }
 


### PR DESCRIPTION
This is a PR that allows ERA5 data to be viewed in the mapping tool.

If we choose to consolidate catalogs and show ERA5 data alongside the CMIP6 data, we'll need to figure out how to (1) update the filtering section to handle the ERA5 <> CMIP6 distinction and (2) reconcile the different time extents.