### PR TITLE
Combine ERA5 and CMIP6 datasets

### DIFF
--- a/components/datasets/date-strings.js
+++ b/components/datasets/date-strings.js
@@ -162,6 +162,13 @@ class DateStrings {
     }
   }
 
+  getYearRange() {
+    const first = this._indexToValues(0)
+    const last = this._indexToValues(this.length - 1)
+
+    return [first.year, last.year]
+  }
+
   getDayRange({ year, month }) {
     const times = this.getDisplayRange({ year, month })
 

--- a/components/datasets/store.js
+++ b/components/datasets/store.js
@@ -46,7 +46,6 @@ const getInitialFilters = (datasets) => {
     },
     {
       variable: 'tasmax',
-      observational: true,
       timescale: 'year',
       experiment: { historical: false },
       gcm: {},

--- a/components/datasets/store.js
+++ b/components/datasets/store.js
@@ -73,7 +73,7 @@ export const useDatasetsStore = create((set, get) => ({
 
     const datasets = {
       ...getInitialDatasets(data[0]),
-      ...getInitialDatasets(data[1], { era5: true, experiment: 'historical' }),
+      ...getInitialDatasets(data[1], { era5: true }),
     }
     const filters = getInitialFilters(datasets)
 

--- a/components/datasets/store.js
+++ b/components/datasets/store.js
@@ -29,7 +29,7 @@ const getInitialDatasets = (data, attrs) => {
       loaded: false,
       colormapName: null,
       clim: null,
-      ...attrs,
+      era5: dataset.experiment_id === 'reanalysis',
     }
     return accum
   }, {})
@@ -61,20 +61,13 @@ export const useDatasetsStore = create((set, get) => ({
   displayTime: DEFAULT_DISPLAY_TIMES.HISTORICAL,
   updatingTime: false,
   fetchDatasets: async () => {
-    const results = await Promise.all([
-      fetch(
-        'https://cmip6downscaling.blob.core.windows.net/flow-outputs/results/pyramids/cmip6/cmip6-pyramids-catalog-web.json'
-      ),
-      fetch(
-        'https://cmip6downscaling.blob.core.windows.net/flow-outputs/results/pyramids/era5/era5-pyramids-catalog-web.json'
-      ),
-    ])
-    const data = await Promise.all(results.map((r) => r.json()))
+    const result = await fetch(
+      'https://cmip6downscaling.blob.core.windows.net/flow-outputs/results/pyramids/combined-cmip6-era5-pyramids-catalog-web.json'
+    )
 
-    const datasets = {
-      ...getInitialDatasets(data[0]),
-      ...getInitialDatasets(data[1], { era5: true }),
-    }
+    const data = await result.json()
+
+    const datasets = getInitialDatasets(data)
     const filters = getInitialFilters(datasets)
 
     set({ datasets, filters })

--- a/components/datasets/utils.js
+++ b/components/datasets/utils.js
@@ -5,11 +5,7 @@ export const getFiltersCallback = (filters) => {
     }
 
     if (d.era5) {
-      if (!filters.observational) {
-        return false
-      } else {
-        return filters.experiment[d.experiment]
-      }
+      return filters.experiment[d.experiment]
     } else {
       return (
         filters.experiment[d.experiment] &&
@@ -76,7 +72,7 @@ export const getShortName = (dataset, filters) => {
   const { experiment, gcm, method, era5 } = dataset
 
   if (era5) {
-    return 'ERA5'
+    return 'Observational*'
   }
 
   const attributes = [gcm, method]

--- a/components/datasets/utils.js
+++ b/components/datasets/utils.js
@@ -1,10 +1,23 @@
 export const getFiltersCallback = (filters) => {
-  return (d) =>
-    d.variable === filters.variable &&
-    d.timescale === filters.timescale &&
-    filters.experiment[d.experiment] &&
-    filters.gcm[d.gcm] &&
-    filters.method[d.method]
+  return (d) => {
+    if (d.variable !== filters.variable || d.timescale !== filters.timescale) {
+      return false
+    }
+
+    if (d.era5) {
+      if (!filters.observational) {
+        return false
+      } else {
+        return filters.experiment[d.experiment]
+      }
+    } else {
+      return (
+        filters.experiment[d.experiment] &&
+        filters.gcm[d.gcm] &&
+        filters.method[d.method]
+      )
+    }
+  }
 }
 
 export const areSiblings = (d1, d2) => {
@@ -60,7 +73,11 @@ const EXPERIMENTS = {
   ssp585: 'SSP5-8.5',
 }
 export const getShortName = (dataset, filters) => {
-  const { experiment, gcm, method } = dataset
+  const { experiment, gcm, method, era5 } = dataset
+
+  if (era5) {
+    return 'ERA5'
+  }
 
   const attributes = [gcm, method]
   if (!filters.experiment.historical) {

--- a/components/datasets/utils.js
+++ b/components/datasets/utils.js
@@ -5,7 +5,7 @@ export const getFiltersCallback = (filters) => {
     }
 
     if (d.era5) {
-      return filters.experiment[d.experiment]
+      return filters.experiment.historical
     } else {
       return (
         filters.experiment[d.experiment] &&

--- a/components/sections/display/display-editor.js
+++ b/components/sections/display/display-editor.js
@@ -54,7 +54,13 @@ const DisplayEditor = ({ sx }) => {
 
       <Column start={[1, 1, 3, 3]} width={[6, 4, 2, 2]}>
         <Box>
-          <Box sx={{ ...sx.label, mb: '5px' }}>Color range</Box>
+          <Box sx={{ ...sx.label, mb: '5px' }}>
+            Color range (
+            <Box as='span' sx={{ textTransform: 'none' }}>
+              {variable === 'pr' ? 'mm' : 'K'}
+            </Box>
+            )
+          </Box>
           <Colorbar
             colormap={colormap}
             clim={clim}

--- a/components/sections/query/dataset-info.js
+++ b/components/sections/query/dataset-info.js
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { alpha } from '@theme-ui/color'
+
 import { Column, Row, Button } from '@carbonplan/components'
 import { Down } from '@carbonplan/icons'
 import { Box } from 'theme-ui'
@@ -8,24 +8,21 @@ const getSx = (color) => ({
   row: {
     borderStyle: 'solid',
     borderWidth: '0px',
-    borderColor: alpha(color, 0.25),
+    borderColor: color,
     borderBottomWidth: '1px',
-    py: 2,
     mb: ['2px'],
   },
   index: {
     textTransform: 'uppercase',
-    letterSpacing: 'smallcaps',
     color,
-    fontFamily: 'heading',
-    fontSize: [2, 2, 2, 3],
-  },
-  entry: {
-    fontSize: [2, 2, 2, 3],
     fontFamily: 'faux',
     letterSpacing: 'faux',
-    mb: ['1px'],
-    mt: [2, 0, 0, 0],
+    fontSize: [1, 1, 1, 2],
+  },
+  entry: {
+    fontSize: [1, 1, 1, 2],
+    fontFamily: 'faux',
+    letterSpacing: 'faux',
   },
 })
 const DatasetInfo = ({ dataset, color }) => {
@@ -55,21 +52,17 @@ const DatasetInfo = ({ dataset, color }) => {
     setTick(timeout)
   }
 
-  let copyText = 'Zarr store'
+  let copyText = 'Copy Zarr store link'
 
   if (copied) {
     copyText = 'Copied!'
   } else if (dataset.original_dataset_uris.length > 1) {
-    copyText = 'Zarr stores'
+    copyText = 'Copy Zarr store links'
   }
 
   return (
     <Row columns={[6, 8, 4, 4]}>
-      <Column
-        start={1}
-        width={[6, 8, 4, 4]}
-        sx={{ bg: alpha(color, 0.25), my: 2, py: 1, px: '24px' }}
-      >
+      <Column start={1} width={[6, 8, 4, 4]} sx={{ pt: 1 }}>
         <Box as='table' sx={{ display: 'block' }}>
           <Box as='tbody' sx={{ display: 'block' }}>
             {dataset.era5 && (
@@ -80,7 +73,7 @@ const DatasetInfo = ({ dataset, color }) => {
                 <Column
                   as='td'
                   start={[4, 3, 3, 3]}
-                  width={[3, 2, 2, 3]}
+                  width={[3, 2, 2, 2]}
                   sx={sx.entry}
                 >
                   ERA5
@@ -94,7 +87,7 @@ const DatasetInfo = ({ dataset, color }) => {
               <Column
                 as='td'
                 start={[4, 3, 3, 3]}
-                width={[3, 2, 2, 3]}
+                width={[3, 2, 2, 2]}
                 sx={sx.entry}
               >
                 {dataset.institution}
@@ -108,7 +101,7 @@ const DatasetInfo = ({ dataset, color }) => {
                 <Column
                   as='td'
                   start={[4, 3, 3, 3]}
-                  width={[3, 2, 2, 3]}
+                  width={[3, 2, 2, 2]}
                   sx={sx.entry}
                 >
                   {dataset.member}
@@ -122,7 +115,7 @@ const DatasetInfo = ({ dataset, color }) => {
               <Column
                 as='td'
                 start={[4, 3, 3, 3]}
-                width={[3, 2, 2, 3]}
+                width={[3, 2, 2, 2]}
                 sx={sx.entry}
               >
                 {dataset.aggregation}
@@ -137,7 +130,8 @@ const DatasetInfo = ({ dataset, color }) => {
                 <Button
                   prefix={<Down />}
                   sx={{
-                    color: alpha(color, 0.75),
+                    fontSize: [1, 1, 1, 2],
+                    color,
                     '@media (hover: hover) and (pointer: fine)': {
                       '&:hover': {
                         color,

--- a/components/sections/query/dataset-info.js
+++ b/components/sections/query/dataset-info.js
@@ -85,19 +85,21 @@ const DatasetInfo = ({ dataset, color }) => {
                 {dataset.institution}
               </Column>
             </Row>
-            <Row as='tr' columns={[6, 8, 4, 4]} sx={sx.row}>
-              <Column as='td' start={[1]} width={[3, 2, 2, 2]} sx={sx.index}>
-                Member
-              </Column>
-              <Column
-                as='td'
-                start={[4, 3, 3, 3]}
-                width={[3, 2, 2, 3]}
-                sx={sx.entry}
-              >
-                {dataset.member}
-              </Column>
-            </Row>
+            {dataset.member && (
+              <Row as='tr' columns={[6, 8, 4, 4]} sx={sx.row}>
+                <Column as='td' start={[1]} width={[3, 2, 2, 2]} sx={sx.index}>
+                  Member
+                </Column>
+                <Column
+                  as='td'
+                  start={[4, 3, 3, 3]}
+                  width={[3, 2, 2, 3]}
+                  sx={sx.entry}
+                >
+                  {dataset.member}
+                </Column>
+              </Row>
+            )}{' '}
             <Row as='tr' columns={[6, 8, 4, 4]} sx={sx.row}>
               <Column as='td' start={[1]} width={[3, 2, 2, 2]} sx={sx.index}>
                 Aggregation

--- a/components/sections/query/dataset-info.js
+++ b/components/sections/query/dataset-info.js
@@ -72,6 +72,21 @@ const DatasetInfo = ({ dataset, color }) => {
       >
         <Box as='table' sx={{ display: 'block' }}>
           <Box as='tbody' sx={{ display: 'block' }}>
+            {dataset.era5 && (
+              <Row as='tr' columns={[6, 8, 4, 4]} sx={sx.row}>
+                <Column as='td' start={[1]} width={[3, 2, 2, 2]} sx={sx.index}>
+                  Reanalysis
+                </Column>
+                <Column
+                  as='td'
+                  start={[4, 3, 3, 3]}
+                  width={[3, 2, 2, 3]}
+                  sx={sx.entry}
+                >
+                  ERA5
+                </Column>
+              </Row>
+            )}
             <Row as='tr' columns={[6, 8, 4, 4]} sx={sx.row}>
               <Column as='td' start={[1]} width={[3, 2, 2, 2]} sx={sx.index}>
                 Institution

--- a/components/sections/query/dataset-info.js
+++ b/components/sections/query/dataset-info.js
@@ -2,7 +2,7 @@ import { useState } from 'react'
 
 import { Column, Row, Button } from '@carbonplan/components'
 import { Down } from '@carbonplan/icons'
-import { Box } from 'theme-ui'
+import { Box, Flex } from 'theme-ui'
 
 const getSx = (color) => ({
   row: {
@@ -18,6 +18,7 @@ const getSx = (color) => ({
     fontFamily: 'faux',
     letterSpacing: 'faux',
     fontSize: [1, 1, 1, 2],
+    mb: 1,
   },
   entry: {
     fontSize: [1, 1, 1, 2],
@@ -62,91 +63,46 @@ const DatasetInfo = ({ dataset, color }) => {
 
   return (
     <Row columns={[6, 8, 4, 4]}>
-      <Column start={1} width={[6, 8, 4, 4]} sx={{ pt: 1 }}>
-        <Box as='table' sx={{ display: 'block' }}>
-          <Box as='tbody' sx={{ display: 'block' }}>
-            {dataset.era5 && (
-              <Row as='tr' columns={[6, 8, 4, 4]} sx={sx.row}>
-                <Column as='td' start={[1]} width={[3, 2, 2, 2]} sx={sx.index}>
-                  Reanalysis
-                </Column>
-                <Column
-                  as='td'
-                  start={[4, 3, 3, 3]}
-                  width={[3, 2, 2, 2]}
-                  sx={sx.entry}
-                >
-                  ERA5
-                </Column>
-              </Row>
-            )}
-            <Row as='tr' columns={[6, 8, 4, 4]} sx={sx.row}>
-              <Column as='td' start={[1]} width={[3, 2, 2, 2]} sx={sx.index}>
-                Institution
-              </Column>
-              <Column
-                as='td'
-                start={[4, 3, 3, 3]}
-                width={[3, 2, 2, 2]}
-                sx={sx.entry}
-              >
-                {dataset.institution}
-              </Column>
-            </Row>
-            {dataset.member && (
-              <Row as='tr' columns={[6, 8, 4, 4]} sx={sx.row}>
-                <Column as='td' start={[1]} width={[3, 2, 2, 2]} sx={sx.index}>
-                  Member
-                </Column>
-                <Column
-                  as='td'
-                  start={[4, 3, 3, 3]}
-                  width={[3, 2, 2, 2]}
-                  sx={sx.entry}
-                >
-                  {dataset.member}
-                </Column>
-              </Row>
-            )}{' '}
-            <Row as='tr' columns={[6, 8, 4, 4]} sx={sx.row}>
-              <Column as='td' start={[1]} width={[3, 2, 2, 2]} sx={sx.index}>
-                Aggregation
-              </Column>
-              <Column
-                as='td'
-                start={[4, 3, 3, 3]}
-                width={[3, 2, 2, 2]}
-                sx={sx.entry}
-              >
-                {dataset.aggregation}
-              </Column>
-            </Row>
-            <Row
-              as='tr'
-              columns={[6, 8, 4, 4]}
-              sx={{ ...sx.row, borderBottomWidth: 0 }}
-            >
-              <Column as='td' start={1} width={[6, 8, 4, 4]} sx={sx.entry}>
-                <Button
-                  prefix={<Down />}
-                  sx={{
-                    fontSize: [1, 1, 1, 2],
-                    color,
-                    '@media (hover: hover) and (pointer: fine)': {
-                      '&:hover': {
-                        color,
-                      },
-                    },
-                  }}
-                  onClick={handleClick}
-                  size='xs'
-                >
-                  {copyText}
-                </Button>
-              </Column>
-            </Row>
+      <Column start={1} width={[6, 8, 4, 4]} sx={{ py: 3 }}>
+        <Flex sx={{ gap: [4, 5, 5, 6], mb: 3 }}>
+          {dataset.era5 && (
+            <Box>
+              <Box sx={sx.index}>Reanalysis</Box>
+              <Box sx={sx.entry}>ERA5</Box>
+            </Box>
+          )}
+
+          <Box>
+            <Box sx={sx.index}>Institution</Box>
+            <Box sx={sx.entry}>{dataset.institution}</Box>
           </Box>
-        </Box>
+          {dataset.member && (
+            <Box>
+              <Box sx={sx.index}>Member</Box>
+              <Box sx={sx.entry}>{dataset.member}</Box>
+            </Box>
+          )}
+          <Box>
+            <Box sx={sx.index}>Aggregation</Box>
+            <Box sx={sx.entry}>{dataset.aggregation}</Box>
+          </Box>
+        </Flex>
+        <Button
+          prefix={<Down />}
+          sx={{
+            fontSize: [1, 1, 1, 2],
+            color,
+            '@media (hover: hover) and (pointer: fine)': {
+              '&:hover': {
+                color,
+              },
+            },
+          }}
+          onClick={handleClick}
+          size='xs'
+        >
+          {copyText}
+        </Button>
       </Column>
     </Row>
   )

--- a/components/sections/query/dataset.js
+++ b/components/sections/query/dataset.js
@@ -52,7 +52,7 @@ const Dataset = ({ name, last }) => {
       }}
     >
       <Row columns={[6, 8, 4, 4]}>
-        <Column start={1} width={[4, 7, 3, 3]}>
+        <Column start={1} width={[4, 6, 2, 3]}>
           <Label
             sx={{
               cursor: 'pointer',
@@ -72,7 +72,7 @@ const Dataset = ({ name, last }) => {
             {getShortName(dataset, filters)}
           </Label>
         </Column>
-        <Column start={[5, 8, 4, 4]} width={[2, 1, 1, 1]}>
+        <Column start={[5, 7, 3, 4]} width={[2, 2, 2, 1]}>
           <Box sx={{ mt: '-8px', mr: '2px', float: 'right' }}>
             <Box sx={{ position: 'relative', top: '4px' }}>
               <Label

--- a/components/sections/query/dataset.js
+++ b/components/sections/query/dataset.js
@@ -1,7 +1,7 @@
 import { useState } from 'react'
-import { Box, IconButton, Label } from 'theme-ui'
+import { Box, Label } from 'theme-ui'
 import { Row, Column } from '@carbonplan/components'
-import { Check, Info, Search, X } from '@carbonplan/icons'
+import { Check, Search, X } from '@carbonplan/icons'
 import AnimateHeight from 'react-animate-height'
 import shallow from 'zustand/shallow'
 
@@ -15,6 +15,7 @@ import {
 } from '../../datasets'
 import { useRegionStore } from '../../region'
 import CustomCheckbox from '../../custom-checkbox'
+import Tooltip from '../../tooltip'
 import DatasetInfo from './dataset-info'
 
 const Dataset = ({ name, last }) => {
@@ -120,34 +121,7 @@ const Dataset = ({ name, last }) => {
                   }}
                 />
               </Label>
-              <IconButton
-                onClick={() => setExpanded(!expanded)}
-                role='checkbox'
-                aria-checked={expanded}
-                aria-label='Information'
-                sx={{
-                  cursor: 'pointer',
-                  height: '16px',
-                  width: '16px',
-                  '@media (hover: hover) and (pointer: fine)': {
-                    '&:hover > #info': {
-                      stroke: 'primary',
-                    },
-                  },
-                  p: [0],
-                  transform: 'translate(0px, -4px)',
-                }}
-              >
-                <Info
-                  id='info'
-                  height='16px'
-                  width='16px'
-                  sx={{
-                    stroke: expanded ? 'primary' : 'secondary',
-                    transition: '0.1s',
-                  }}
-                />
-              </IconButton>
+              <Tooltip expanded={expanded} setExpanded={setExpanded} />
             </Box>
           </Box>
         </Column>

--- a/components/sections/query/dataset.js
+++ b/components/sections/query/dataset.js
@@ -1,6 +1,5 @@
 import { useState } from 'react'
-import { Box, Flex, IconButton, Label } from 'theme-ui'
-import { alpha } from '@theme-ui/color'
+import { Box, IconButton, Label } from 'theme-ui'
 import { Row, Column } from '@carbonplan/components'
 import { Check, Info, Search, X } from '@carbonplan/icons'
 import AnimateHeight from 'react-animate-height'
@@ -54,54 +53,24 @@ const Dataset = ({ name, last }) => {
     >
       <Row columns={[6, 8, 4, 4]}>
         <Column start={1} width={[4, 7, 3, 3]}>
-          <Flex sx={{ gap: 2 }}>
-            <IconButton
-              onClick={() => setExpanded(!expanded)}
-              role='checkbox'
-              aria-checked={expanded}
-              aria-label='Information'
-              sx={{
-                cursor: 'pointer',
-                height: '18px',
-                width: '18px',
-                '@media (hover: hover) and (pointer: fine)': {
-                  '&:hover > #info': {
-                    stroke: color,
-                  },
+          <Label
+            sx={{
+              cursor: 'pointer',
+              color,
+              fontFamily: 'faux',
+              letterSpacing: 'faux',
+              fontSize: [1, 1, 1, 2],
+              transition: 'color 0.15s',
+              '@media (hover: hover) and (pointer: fine)': {
+                '&:hover': {
+                  color: activeColor,
                 },
-                p: [0],
-              }}
-            >
-              <Info
-                id='info'
-                height='18px'
-                width='18px'
-                sx={{
-                  stroke: expanded ? color : alpha(color, 0.25),
-                  transition: '0.1s',
-                  transform: 'translate(0px, 2px)',
-                }}
-              />
-            </IconButton>
-            <Label
-              sx={{
-                color,
-                cursor: 'pointer',
-                fontFamily: 'faux',
-                letterSpacing: 'faux',
-                fontSize: [1, 1, 1, 2],
-                transition: 'color 0.15s',
-                '@media (hover: hover) and (pointer: fine)': {
-                  '&:hover': {
-                    color: activeColor,
-                  },
-                },
-              }}
-              htmlFor={name}
-            >
-              {getShortName(dataset, filters)}
-            </Label>
-          </Flex>
+              },
+            }}
+            htmlFor={name}
+          >
+            {getShortName(dataset, filters)}
+          </Label>
         </Column>
         <Column start={[5, 8, 4, 4]} width={[2, 1, 1, 1]}>
           <Box sx={{ mt: '-8px', mr: '2px', float: 'right' }}>
@@ -136,6 +105,7 @@ const Dataset = ({ name, last }) => {
                   width: 'inherit',
                   display: 'inline-block',
                   position: 'relative',
+                  mr: 2,
                 }}
               >
                 <CustomCheckbox
@@ -150,6 +120,34 @@ const Dataset = ({ name, last }) => {
                   }}
                 />
               </Label>
+              <IconButton
+                onClick={() => setExpanded(!expanded)}
+                role='checkbox'
+                aria-checked={expanded}
+                aria-label='Information'
+                sx={{
+                  cursor: 'pointer',
+                  height: '16px',
+                  width: '16px',
+                  '@media (hover: hover) and (pointer: fine)': {
+                    '&:hover > #info': {
+                      stroke: 'primary',
+                    },
+                  },
+                  p: [0],
+                  transform: 'translate(0px, -4px)',
+                }}
+              >
+                <Info
+                  id='info'
+                  height='16px'
+                  width='16px'
+                  sx={{
+                    stroke: expanded ? 'primary' : 'secondary',
+                    transition: '0.1s',
+                  }}
+                />
+              </IconButton>
             </Box>
           </Box>
         </Column>

--- a/components/sections/query/query-section.js
+++ b/components/sections/query/query-section.js
@@ -116,15 +116,17 @@ const Filters = ({ sx }) => {
       </Row>
       <Row columns={[6, 8, 4, 4]}>
         <Column start={1} width={[2, 2, 1, 1]} sx={sx.label}>
-          GCMs
+          Timescale
         </Column>
         <Column start={[3, 3, 2, 2]} width={[4, 6, 3, 3]}>
-          <ExpandableFilter
-            values={filters.gcm}
+          <Filter
+            values={timescaleFilter}
             setValues={(obj) => {
-              setFilters({ gcm: obj })
+              const timescale = Object.keys(LABEL_MAP).find(
+                (k) => obj[LABEL_MAP[k]]
+              )
+              setFilters({ timescale })
             }}
-            multiSelect
           />
         </Column>
       </Row>
@@ -180,6 +182,21 @@ const Filters = ({ sx }) => {
           />
         </Column>
       </Row>
+
+      <Row columns={[6, 8, 4, 4]}>
+        <Column start={1} width={[2, 2, 1, 1]} sx={sx.label}>
+          GCMs
+        </Column>
+        <Column start={[3, 3, 2, 2]} width={[4, 6, 3, 3]}>
+          <ExpandableFilter
+            values={filters.gcm}
+            setValues={(obj) => {
+              setFilters({ gcm: obj })
+            }}
+            multiSelect
+          />
+        </Column>
+      </Row>
       <Row columns={[6, 8, 4, 4]}>
         <Column start={1} width={[2, 2, 1, 1]} sx={sx.label}>
           Methods
@@ -194,19 +211,15 @@ const Filters = ({ sx }) => {
           />
         </Column>
       </Row>
+
       <Row columns={[6, 8, 4, 4]}>
         <Column start={1} width={[2, 2, 1, 1]} sx={sx.label}>
-          Timescale
+          Observational
         </Column>
         <Column start={[3, 3, 2, 2]} width={[4, 6, 3, 3]}>
           <Filter
-            values={timescaleFilter}
-            setValues={(obj) => {
-              const timescale = Object.keys(LABEL_MAP).find(
-                (k) => obj[LABEL_MAP[k]]
-              )
-              setFilters({ timescale })
-            }}
+            values={{ include: true, exclude: false }}
+            setValues={(obj) => setFilters({ observational: obj.include })}
           />
         </Column>
       </Row>

--- a/components/sections/query/query-section.js
+++ b/components/sections/query/query-section.js
@@ -218,7 +218,10 @@ const Filters = ({ sx }) => {
         </Column>
         <Column start={[3, 3, 2, 2]} width={[4, 6, 3, 3]}>
           <Filter
-            values={{ include: true, exclude: false }}
+            values={{
+              include: filters.observational,
+              exclude: !filters.observational,
+            }}
             setValues={(obj) => setFilters({ observational: obj.include })}
           />
         </Column>

--- a/components/sections/query/query-section.js
+++ b/components/sections/query/query-section.js
@@ -211,21 +211,6 @@ const Filters = ({ sx }) => {
           />
         </Column>
       </Row>
-
-      <Row columns={[6, 8, 4, 4]}>
-        <Column start={1} width={[2, 2, 1, 1]} sx={sx.label}>
-          Observational
-        </Column>
-        <Column start={[3, 3, 2, 2]} width={[4, 6, 3, 3]}>
-          <Filter
-            values={{
-              include: filters.observational,
-              exclude: !filters.observational,
-            }}
-            setValues={(obj) => setFilters({ observational: obj.include })}
-          />
-        </Column>
-      </Row>
     </>
   )
 }

--- a/components/sections/query/query-section.js
+++ b/components/sections/query/query-section.js
@@ -1,4 +1,4 @@
-import { Box, Divider, Spinner } from 'theme-ui'
+import { Box, Divider, Flex, Spinner } from 'theme-ui'
 import { useEffect, useMemo } from 'react'
 import shallow from 'zustand/shallow'
 import { Badge, Column, Filter, Group, Row } from '@carbonplan/components'
@@ -7,7 +7,7 @@ import { getFiltersCallback, useDatasetsStore } from '../../datasets'
 import ExpandableFilter from './expandable-filter'
 import Dataset from './dataset'
 import { useRegionStore } from '../../region'
-
+import TooltipWrapper from './tooltip-wrapper'
 const formatNumber = (value) => String(value).padStart(2, '0')
 
 const LABEL_MAP = {
@@ -100,18 +100,20 @@ const Filters = ({ sx }) => {
           Variable
         </Column>
         <Column start={[3, 3, 2, 2]} width={[4, 6, 3, 3]}>
-          <Filter
-            values={variableFilter}
-            setValues={(obj) => {
-              const variable = Object.keys(LABEL_MAP).find(
-                (k) => obj[LABEL_MAP[k]]
-              )
-              if (variable !== filters.variable) {
-                setFilters({ variable })
-                clearRegionData()
-              }
-            }}
-          />
+          <TooltipWrapper tooltip='Select climate variable mapped in dataset.'>
+            <Filter
+              values={variableFilter}
+              setValues={(obj) => {
+                const variable = Object.keys(LABEL_MAP).find(
+                  (k) => obj[LABEL_MAP[k]]
+                )
+                if (variable !== filters.variable) {
+                  setFilters({ variable })
+                  clearRegionData()
+                }
+              }}
+            />
+          </TooltipWrapper>
         </Column>
       </Row>
       <Row columns={[6, 8, 4, 4]}>
@@ -119,15 +121,17 @@ const Filters = ({ sx }) => {
           Timescale
         </Column>
         <Column start={[3, 3, 2, 2]} width={[4, 6, 3, 3]}>
-          <Filter
-            values={timescaleFilter}
-            setValues={(obj) => {
-              const timescale = Object.keys(LABEL_MAP).find(
-                (k) => obj[LABEL_MAP[k]]
-              )
-              setFilters({ timescale })
-            }}
-          />
+          <TooltipWrapper tooltip='Select whether to view full daily data or summarized to monthly or annual timesteps.'>
+            <Filter
+              values={timescaleFilter}
+              setValues={(obj) => {
+                const timescale = Object.keys(LABEL_MAP).find(
+                  (k) => obj[LABEL_MAP[k]]
+                )
+                setFilters({ timescale })
+              }}
+            />
+          </TooltipWrapper>
         </Column>
       </Row>
       <Row columns={[6, 8, 4, 4]}>
@@ -135,51 +139,55 @@ const Filters = ({ sx }) => {
           Scenarios
         </Column>
         <Column start={[3, 3, 2, 2]} width={[4, 6, 3, 3]}>
-          <Filter
-            values={historicalFilter}
-            setValues={(obj) => {
-              const historical = obj[LABEL_MAP.historical]
-              const { historical: previousHistorical, ...previousScenarios } =
-                filters.experiment
-              const scenarios = historical
-                ? { ssp245: false, ssp370: false, ssp585: false }
-                : previousScenarios
+          <TooltipWrapper tooltip='Select whether to view historical data or future  data from Shared Socioeconomic Pathways (SSPs) representing different levels of warming.'>
+            <Flex sx={{ flexDirection: 'column' }}>
+              <Filter
+                values={historicalFilter}
+                setValues={(obj) => {
+                  const historical = obj[LABEL_MAP.historical]
+                  const {
+                    historical: previousHistorical,
+                    ...previousScenarios
+                  } = filters.experiment
+                  const scenarios = historical
+                    ? { ssp245: false, ssp370: false, ssp585: false }
+                    : previousScenarios
 
-              setFilters({
-                experiment: {
-                  historical,
-                  ...scenarios,
-                },
-              })
-              clearRegionData()
-            }}
-            multiSelect
-          />
-        </Column>
-      </Row>
-      <Row columns={[6, 8, 4, 4]}>
-        <Column start={[3, 3, 2, 2]} width={[4, 6, 3, 3]}>
-          <Filter
-            values={scenarioFilter}
-            setValues={(obj) => {
-              const scenarioSelected = Object.keys(obj).some((k) => obj[k])
-              const { historical: previousHistorical } = filters.experiment
-              const historical = scenarioSelected ? false : previousHistorical
+                  setFilters({
+                    experiment: {
+                      historical,
+                      ...scenarios,
+                    },
+                  })
+                  clearRegionData()
+                }}
+                multiSelect
+              />
+              <Filter
+                values={scenarioFilter}
+                setValues={(obj) => {
+                  const scenarioSelected = Object.keys(obj).some((k) => obj[k])
+                  const { historical: previousHistorical } = filters.experiment
+                  const historical = scenarioSelected
+                    ? false
+                    : previousHistorical
 
-              setFilters({
-                experiment: {
-                  historical,
-                  ssp245: obj[LABEL_MAP.ssp245],
-                  ssp370: obj[LABEL_MAP.ssp370],
-                  ssp585: obj[LABEL_MAP.ssp585],
-                },
-              })
-              if (historical !== previousHistorical) {
-                clearRegionData()
-              }
-            }}
-            multiSelect
-          />
+                  setFilters({
+                    experiment: {
+                      historical,
+                      ssp245: obj[LABEL_MAP.ssp245],
+                      ssp370: obj[LABEL_MAP.ssp370],
+                      ssp585: obj[LABEL_MAP.ssp585],
+                    },
+                  })
+                  if (historical !== previousHistorical) {
+                    clearRegionData()
+                  }
+                }}
+                multiSelect
+              />
+            </Flex>
+          </TooltipWrapper>
         </Column>
       </Row>
 
@@ -188,13 +196,15 @@ const Filters = ({ sx }) => {
           GCMs
         </Column>
         <Column start={[3, 3, 2, 2]} width={[4, 6, 3, 3]}>
-          <ExpandableFilter
-            values={filters.gcm}
-            setValues={(obj) => {
-              setFilters({ gcm: obj })
-            }}
-            multiSelect
-          />
+          <TooltipWrapper tooltip='Select global climate models (GCMs) used produce either downscaled or raw datasets.'>
+            <ExpandableFilter
+              values={filters.gcm}
+              setValues={(obj) => {
+                setFilters({ gcm: obj })
+              }}
+              multiSelect
+            />
+          </TooltipWrapper>
         </Column>
       </Row>
       <Row columns={[6, 8, 4, 4]}>
@@ -202,13 +212,15 @@ const Filters = ({ sx }) => {
           Methods
         </Column>
         <Column start={[3, 3, 2, 2]} width={[4, 6, 3, 3]}>
-          <Filter
-            values={filters.method}
-            setValues={(obj) => {
-              setFilters({ method: obj })
-            }}
-            multiSelect
-          />
+          <TooltipWrapper tooltip='Select downscaling method used to derive datasets.'>
+            <Filter
+              values={filters.method}
+              setValues={(obj) => {
+                setFilters({ method: obj })
+              }}
+              multiSelect
+            />
+          </TooltipWrapper>
         </Column>
       </Row>
     </>

--- a/components/sections/query/tooltip-wrapper.js
+++ b/components/sections/query/tooltip-wrapper.js
@@ -1,0 +1,27 @@
+import { Box, Flex } from 'theme-ui'
+import { useState } from 'react'
+import AnimateHeight from 'react-animate-height'
+
+import Tooltip from '../../tooltip'
+
+const TooltipWrapper = ({ children, tooltip }) => {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <>
+      <Flex sx={{ justifyContent: 'space-between' }}>
+        {children}
+        <Tooltip expanded={expanded} setExpanded={setExpanded} />
+      </Flex>
+      <AnimateHeight
+        duration={100}
+        height={expanded ? 'auto' : 0}
+        easing={'linear'}
+      >
+        <Box sx={{ my: 1 }}>{tooltip}</Box>
+      </AnimateHeight>
+    </>
+  )
+}
+
+export default TooltipWrapper

--- a/components/sections/region/chart.js
+++ b/components/sections/region/chart.js
@@ -68,6 +68,7 @@ const ChartWrapper = ({ data }) => {
   const [hovered, setHovered] = useState(null)
   const activeDataset = useDatasetsStore((state) => state.active)
   const datasets = useDatasetsStore((state) => state.datasets)
+  const variable = useDatasetsStore((state) => state.filters.variable)
   const display = useDatasetsStore((state) => state.displayTime)
 
   // By default, use active dataset as primary dataset (reference for dateStrings and timescale)
@@ -156,6 +157,12 @@ const ChartWrapper = ({ data }) => {
     }, [])
 
   const loading = data.some(([name, value]) => !value)
+  const units = (
+    <Box as='span' sx={{ textTransform: 'none' }}>
+      {variable === 'pr' ? 'mm' : 'K'}
+    </Box>
+  )
+
   return (
     <Box
       sx={{
@@ -199,7 +206,8 @@ const ChartWrapper = ({ data }) => {
                 color: 'secondary',
               }}
             >
-              ({dateStrings.formatTick(displayTime)}, {formatValue(label[1])}K)
+              ({dateStrings.formatTick(displayTime)}, {formatValue(label[1])}
+              {units})
             </Box>
           </Box>
         )}

--- a/components/sections/time/sliders.js
+++ b/components/sections/time/sliders.js
@@ -88,11 +88,6 @@ const TimeSlider = ({
   )
 }
 
-const YEAR_RANGES = {
-  HISTORICAL: [1950, 2014],
-  PROJECTED: [2015, 2100],
-}
-
 const Sliders = ({ dateStrings, historical = false }) => {
   const display = useDatasetsStore((state) => state.displayTime)
   const timescale = useDatasetsStore((state) => state.filters.timescale)
@@ -101,7 +96,7 @@ const Sliders = ({ dateStrings, historical = false }) => {
 
   const ranges = useMemo(() => {
     return {
-      year: historical ? YEAR_RANGES.HISTORICAL : YEAR_RANGES.PROJECTED,
+      year: dateStrings.getYearRange(),
       month: [1, 12],
       day: timescale === 'day' ? dateStrings.getDayRange(display) : [],
     }

--- a/components/tooltip.js
+++ b/components/tooltip.js
@@ -1,0 +1,37 @@
+import { IconButton } from 'theme-ui'
+import { Info } from '@carbonplan/icons'
+
+const Tooltip = ({ expanded, setExpanded }) => {
+  return (
+    <IconButton
+      onClick={() => setExpanded(!expanded)}
+      role='checkbox'
+      aria-checked={expanded}
+      aria-label='Information'
+      sx={{
+        cursor: 'pointer',
+        height: '16px',
+        width: '16px',
+        '@media (hover: hover) and (pointer: fine)': {
+          '&:hover > #info': {
+            stroke: 'primary',
+          },
+        },
+        p: [0],
+        transform: 'translate(0px, -4px)',
+      }}
+    >
+      <Info
+        id='info'
+        height='16px'
+        width='16px'
+        sx={{
+          stroke: expanded ? 'primary' : 'secondary',
+          transition: '0.1s',
+        }}
+      />
+    </IconButton>
+  )
+}
+
+export default Tooltip


### PR DESCRIPTION
- Fetches ERA5 + CMIP6 catalogs and combines
  - Tags ERA5 pyramids with `era5=true`
- Include ERA5 pyramids in results list when new `filter.observational=true` and `filter.experiment.historical=true`
- Dynamically sets year ranges based on range of currently mapped pyramid