### PR TITLE
Initialize and track state in query params

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ci:
-   autoupdate_schedule: quarterly
-   autofix_prs: false
+  autoupdate_schedule: quarterly
+  autofix_prs: false
 
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/components/sections/query/dataset.js
+++ b/components/sections/query/dataset.js
@@ -1,6 +1,5 @@
 import { useState } from 'react'
-import { Box, Label } from 'theme-ui'
-import { Row, Column } from '@carbonplan/components'
+import { Box, Flex, Label } from 'theme-ui'
 import { Check, Search, X } from '@carbonplan/icons'
 import AnimateHeight from 'react-animate-height'
 import shallow from 'zustand/shallow'
@@ -53,82 +52,78 @@ const Dataset = ({ name, last }) => {
           : 'none',
       }}
     >
-      <Row columns={[6, 8, 4, 4]}>
-        <Column start={1} width={[4, 6, 2, 3]}>
-          <Label
-            sx={{
-              cursor: 'pointer',
-              color,
-              fontFamily: 'faux',
-              letterSpacing: 'faux',
-              fontSize: [1, 1, 1, 2],
-              transition: 'color 0.15s',
-              '@media (hover: hover) and (pointer: fine)': {
-                '&:hover': {
-                  color: activeColor,
-                },
+      <Flex sx={{ justifyContent: 'space-between', flexDirection: 'row' }}>
+        <Label
+          sx={{
+            cursor: 'pointer',
+            color,
+            fontFamily: 'faux',
+            letterSpacing: 'faux',
+            fontSize: [1, 1, 1, 2],
+            transition: 'color 0.15s',
+            '@media (hover: hover) and (pointer: fine)': {
+              '&:hover': {
+                color: activeColor,
               },
-            }}
-            htmlFor={name}
-            onMouseOver={() => setHovered(name)}
-            onMouseLeave={() => setHovered(null)}
-          >
-            {getShortName(dataset, filters)}
-          </Label>
-        </Column>
-        <Column start={[5, 7, 3, 4]} width={[2, 2, 2, 1]}>
-          <Box sx={{ mt: '-8px', mr: '2px', float: 'right' }}>
-            <Box sx={{ position: 'relative', top: '4px' }}>
-              <Label
-                sx={{
-                  width: 'inherit',
-                  display: 'inline-block',
-                  position: 'relative',
-                  mr: 2,
+            },
+          }}
+          htmlFor={name}
+          onMouseOver={() => setHovered(name)}
+          onMouseLeave={() => setHovered(null)}
+        >
+          {getShortName(dataset, filters)}
+        </Label>
+        <Box sx={{ mt: '-8px', flexShrink: 0 }}>
+          <Box sx={{ position: 'relative', top: '4px' }}>
+            <Label
+              sx={{
+                width: 'inherit',
+                display: 'inline-block',
+                position: 'relative',
+                mr: 2,
+              }}
+            >
+              <CustomCheckbox
+                uncheckedIcon={Search}
+                checkedIcon={Check}
+                checkedHoverIcon={X}
+                checked={selected}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    selectDataset(name)
+                    if (!anyActive) setActive(name)
+                    openRegionPicker()
+                  } else {
+                    deselectDataset(name)
+                    setRegionData(name, null)
+                  }
                 }}
-              >
-                <CustomCheckbox
-                  uncheckedIcon={Search}
-                  checkedIcon={Check}
-                  checkedHoverIcon={X}
-                  checked={selected}
-                  onChange={(e) => {
-                    if (e.target.checked) {
-                      selectDataset(name)
-                      if (!anyActive) setActive(name)
-                      openRegionPicker()
-                    } else {
-                      deselectDataset(name)
-                      setRegionData(name, null)
-                    }
-                  }}
-                />
-              </Label>
-              <Label
-                sx={{
-                  width: 'inherit',
-                  display: 'inline-block',
-                  position: 'relative',
-                  mr: 2,
+              />
+            </Label>
+            <Label
+              sx={{
+                width: 'inherit',
+                display: 'inline-block',
+                position: 'relative',
+                mr: 2,
+              }}
+            >
+              <CustomCheckbox
+                id={name}
+                uncheckedIcon={Eye}
+                checkedIcon={EyeFilled}
+                checked={active}
+                onChange={(e) => {
+                  if (e.target.checked && !active) {
+                    setActive(name)
+                  }
                 }}
-              >
-                <CustomCheckbox
-                  id={name}
-                  uncheckedIcon={Eye}
-                  checkedIcon={EyeFilled}
-                  checked={active}
-                  onChange={(e) => {
-                    if (e.target.checked && !active) {
-                      setActive(name)
-                    }
-                  }}
-                />
-              </Label>
-              <Tooltip expanded={expanded} setExpanded={setExpanded} />
-            </Box>
+              />
+            </Label>
+            <Tooltip expanded={expanded} setExpanded={setExpanded} />
           </Box>
-        </Column>
-      </Row>
+        </Box>
+      </Flex>
       <AnimateHeight
         duration={100}
         height={expanded ? 'auto' : 0}

--- a/components/sections/query/query-section.js
+++ b/components/sections/query/query-section.js
@@ -8,6 +8,7 @@ import ExpandableFilter from './expandable-filter'
 import Dataset from './dataset'
 import { useRegionStore } from '../../region'
 import TooltipWrapper from './tooltip-wrapper'
+import { useRouter } from 'next/router'
 const formatNumber = (value) => String(value).padStart(2, '0')
 
 const LABEL_MAP = {
@@ -230,12 +231,30 @@ const Filters = ({ sx }) => {
 const QuerySection = ({ sx }) => {
   const datasets = useDatasetsStore((state) => !!state.datasets)
   const fetchDatasets = useDatasetsStore((state) => state.fetchDatasets)
+  const setActive = useDatasetsStore((state) => state.setActive)
+  const setDisplayTime = useDatasetsStore((state) => state.setDisplayTime)
+  const router = useRouter()
 
   useEffect(() => {
     if (!datasets) {
       fetchDatasets()
     }
   }, [])
+
+  useEffect(() => {
+    if (router.isReady && datasets) {
+      console.log('setting from query', router.query)
+
+      const { active, year, month, day } = router.query
+      if (active) {
+        setActive(active)
+      }
+
+      if (year && month && day) {
+        setDisplayTime({ year, month, day })
+      }
+    }
+  }, [datasets, router.isReady])
 
   return (
     <Box>

--- a/components/sections/query/query-section.js
+++ b/components/sections/query/query-section.js
@@ -231,30 +231,12 @@ const Filters = ({ sx }) => {
 const QuerySection = ({ sx }) => {
   const datasets = useDatasetsStore((state) => !!state.datasets)
   const fetchDatasets = useDatasetsStore((state) => state.fetchDatasets)
-  const setActive = useDatasetsStore((state) => state.setActive)
-  const setDisplayTime = useDatasetsStore((state) => state.setDisplayTime)
-  const router = useRouter()
 
   useEffect(() => {
     if (!datasets) {
       fetchDatasets()
     }
   }, [])
-
-  useEffect(() => {
-    if (router.isReady && datasets) {
-      console.log('setting from query', router.query)
-
-      const { active, year, month, day } = router.query
-      if (active) {
-        setActive(active)
-      }
-
-      if (year && month && day) {
-        setDisplayTime({ year, month, day })
-      }
-    }
-  }, [datasets, router.isReady])
 
   return (
     <Box>

--- a/components/sections/query/query-section.js
+++ b/components/sections/query/query-section.js
@@ -8,7 +8,7 @@ import ExpandableFilter from './expandable-filter'
 import Dataset from './dataset'
 import { useRegionStore } from '../../region'
 import TooltipWrapper from './tooltip-wrapper'
-import { useRouter } from 'next/router'
+
 const formatNumber = (value) => String(value).padStart(2, '0')
 
 const LABEL_MAP = {

--- a/components/use-routing.js
+++ b/components/use-routing.js
@@ -12,7 +12,24 @@ const useRouting = () => {
       (state) => state.datasets && state.datasets[state.active]
     ) || {}
   const displayTime = useDatasetsStore((state) => state.displayTime)
+  const setActive = useDatasetsStore((state) => state.setActive)
+  const setDisplayTime = useDatasetsStore((state) => state.setDisplayTime)
 
+  // Sets values in the store based on the initial URL parameters
+  useEffect(() => {
+    if (router.isReady && initialized) {
+      const { active, year, month, day } = router.query
+      if (active) {
+        setActive(active)
+      }
+
+      if (year && month && day) {
+        setDisplayTime({ year, month, day })
+      }
+    }
+  }, [initialized, router.isReady])
+
+  // Update the URL when the active dataset changes or the display time changes.
   useEffect(() => {
     if (initialized) {
       const query = {
@@ -23,8 +40,6 @@ const useRouting = () => {
       router.replace({ pathname: '', query }, null, {
         shallow: true,
       })
-
-      console.log({ active, displayTime })
     }
   }, [initialized, active, displayTime])
 }

--- a/components/use-routing.js
+++ b/components/use-routing.js
@@ -19,10 +19,8 @@ const useRouting = () => {
   // Sets values in the store based on the initial URL parameters
   useEffect(() => {
     if (router.isReady && initialized) {
+      const { query } = router
       const {
-        active,
-        variable,
-        timescale,
         // displayTime values
         year,
         month,
@@ -32,11 +30,11 @@ const useRouting = () => {
         ssp245,
         ssp370,
         ssp585,
-      } = router.query
+      } = query
 
       const filters = {
-        ...(variable ? { variable } : {}),
-        ...(timescale ? { timescale } : {}),
+        ...(query.variable ? { variable: query.variable } : {}),
+        ...(query.timescale ? { timescale: query.timescale } : {}),
         ...(historical || ssp245 || ssp370 || ssp585
           ? {
               experiment: {
@@ -53,8 +51,8 @@ const useRouting = () => {
         setFilters(filters)
       }
 
-      if (active) {
-        setActive(active)
+      if (query.active) {
+        setActive(query.active)
       }
 
       if (year && month && day) {

--- a/components/use-routing.js
+++ b/components/use-routing.js
@@ -7,18 +7,52 @@ import { useDatasetsStore } from './datasets'
 const useRouting = () => {
   const router = useRouter()
   const initialized = useDatasetsStore((state) => !!state.datasets)
-  const { name: active, dateStrings } =
-    useDatasetsStore(
-      (state) => state.datasets && state.datasets[state.active]
-    ) || {}
+  const active = useDatasetsStore((state) => state.active)
   const displayTime = useDatasetsStore((state) => state.displayTime)
+  const variable = useDatasetsStore((state) => state.filters?.variable)
+  const timescale = useDatasetsStore((state) => state.filters?.timescale)
+  const experiment = useDatasetsStore((state) => state.filters?.experiment)
   const setActive = useDatasetsStore((state) => state.setActive)
   const setDisplayTime = useDatasetsStore((state) => state.setDisplayTime)
+  const setFilters = useDatasetsStore((state) => state.setFilters)
 
   // Sets values in the store based on the initial URL parameters
   useEffect(() => {
     if (router.isReady && initialized) {
-      const { active, year, month, day } = router.query
+      const {
+        active,
+        variable,
+        timescale,
+        // displayTime values
+        year,
+        month,
+        day,
+        // experiment values
+        historical,
+        ssp245,
+        ssp370,
+        ssp585,
+      } = router.query
+
+      const filters = {
+        ...(variable ? { variable } : {}),
+        ...(timescale ? { timescale } : {}),
+        ...(historical || ssp245 || ssp370 || ssp585
+          ? {
+              experiment: {
+                historical: historical === 'true',
+                ssp245: ssp245 === 'true',
+                ssp370: ssp370 === 'true',
+                ssp585: ssp585 === 'true',
+              },
+            }
+          : {}),
+      }
+
+      if (Object.keys(filters).length > 0) {
+        setFilters(filters)
+      }
+
       if (active) {
         setActive(active)
       }
@@ -35,13 +69,16 @@ const useRouting = () => {
       const query = {
         ...(active ? { active } : {}),
         ...(displayTime ? displayTime : {}),
+        ...(experiment ? experiment : {}),
+        ...(variable ? { variable } : {}),
+        ...(timescale ? { timescale } : {}),
       }
 
       router.replace({ pathname: '', query }, null, {
         shallow: true,
       })
     }
-  }, [initialized, active, displayTime])
+  }, [initialized, active, displayTime, variable, timescale, experiment])
 }
 
 export default useRouting

--- a/components/use-routing.js
+++ b/components/use-routing.js
@@ -1,0 +1,32 @@
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+import { useDatasetsStore } from './datasets'
+
+// Listens for changes in datasets zustand store and updates the query
+// parameters of the url.
+const useRouting = () => {
+  const router = useRouter()
+  const initialized = useDatasetsStore((state) => !!state.datasets)
+  const { name: active, dateStrings } =
+    useDatasetsStore(
+      (state) => state.datasets && state.datasets[state.active]
+    ) || {}
+  const displayTime = useDatasetsStore((state) => state.displayTime)
+
+  useEffect(() => {
+    if (initialized) {
+      const query = {
+        ...(active ? { active } : {}),
+        ...(displayTime ? displayTime : {}),
+      }
+
+      router.replace({ pathname: '', query }, null, {
+        shallow: true,
+      })
+
+      console.log({ active, displayTime })
+    }
+  }, [initialized, active, displayTime])
+}
+
+export default useRouting

--- a/tool/index.js
+++ b/tool/index.js
@@ -16,6 +16,7 @@ import {
 import Map from '../components/map'
 import { useRegionStore } from '../components/region'
 import LoadingStates from '../components/loading-states'
+import useRouting from '../components/use-routing'
 
 const sx = {
   heading: {
@@ -39,6 +40,7 @@ const sx = {
 }
 
 const Tool = () => {
+  useRouting()
   const index = useBreakpointIndex({ defaultIndex: 2 })
   const [expanded, setExpanded] = useState(index >= 2)
   const [loading, setLoading] = useState(false)


### PR DESCRIPTION
Creates `useRouting` hook which manages:
- updating query params based on changes in zustand store
  - tracks changes to `active` dataset, `displayTime`, and filters for `experiment`, `timescale`, and `variable`
- initializing store with values from router
  - triggered by `router.isReady`
  - occurs after catalog is fetched