### PR TITLE
regional chart fixes

### DIFF
--- a/components/datasets/date-strings.js
+++ b/components/datasets/date-strings.js
@@ -77,10 +77,8 @@ class DateStrings {
   }
 
   formatTick(time) {
-    const initialTime = this._indexToDate(0)
-    const offset = time - this.time[0]
+    const date = this._indexToDate(this.time.indexOf(time))
 
-    const date = timeDay.offset(initialTime, offset)
     switch (this.timescale) {
       case 'day':
         return date.toLocaleString('default', {
@@ -124,7 +122,7 @@ class DateStrings {
         return Array(7)
           .fill(null)
           .map((_, i) => this.valuesToTime({ year, month: 1 + 2 * i, day: 1 }))
-          .filter((index) => typeof index === 'number')
+          .filter((time) => typeof time === 'number')
       case 'year':
         const { year: initialYear } = this._indexToValues(0)
         const count = 9

--- a/components/datasets/store.js
+++ b/components/datasets/store.js
@@ -69,6 +69,7 @@ export const useDatasetsStore = create((set, get) => ({
   displayTime: DEFAULT_DISPLAY_TIMES.HISTORICAL,
   displayUnits: DEFAULT_DISPLAY_UNITS.tasmax,
   updatingTime: false,
+  slidingTime: { day: false, month: false, year: false },
   fetchDatasets: async () => {
     const result = await fetch(
       'https://cmip6downscaling.blob.core.windows.net/flow-outputs/results/pyramids/combined-cmip6-era5-pyramids-catalog-web.json'
@@ -84,6 +85,8 @@ export const useDatasetsStore = create((set, get) => ({
   setDisplayTime: (value) => set({ displayTime: value }),
   setDisplayUnits: (value) => set({ displayUnits: value }),
   setUpdatingTime: (value) => set({ updatingTime: value }),
+  setSlidingTime: (key, value) =>
+    set((prev) => ({ slidingTime: { ...prev.slidingTime, [key]: value } })),
   loadDateStrings: async (name) => {
     const [date_str, time] = await Promise.all([
       new Promise((resolve) =>

--- a/components/sections/region/chart.js
+++ b/components/sections/region/chart.js
@@ -81,6 +81,7 @@ const ChartWrapper = ({ data }) => {
   const datasets = useDatasetsStore((state) => state.datasets)
   const display = useDatasetsStore((state) => state.displayTime)
   const displayUnits = useDatasetsStore((state) => state.displayUnits)
+  const sliding = useDatasetsStore((state) => state.slidingTime)
   const setDisplay = useDatasetsStore((state) => state.setDisplayTime)
   const { region } = useRegion()
   const zoom = region?.properties?.zoom || 0
@@ -236,6 +237,20 @@ const ChartWrapper = ({ data }) => {
         )}
 
         <Plot>
+          {!loading && (
+            <Line
+              data={[
+                [dateStrings.valuesToTime(display), range[0]],
+                [dateStrings.valuesToTime(display), range[1]],
+              ]}
+              color='secondary'
+              sx={{
+                opacity: sliding[timescale] ? 1 : 0,
+                strokeDasharray: 4,
+                transition: 'opacity 0.15s',
+              }}
+            />
+          )}
           {!loading &&
             lines
               .sort((a, b) => {

--- a/components/sections/region/chart.js
+++ b/components/sections/region/chart.js
@@ -66,6 +66,7 @@ const LoadingSpinner = ({ opacity = 1 }) => {
         mx: 'auto',
         opacity: opacity,
         transition: 'opacity 0.05s',
+        pointerEvents: 'none',
       }}
     >
       <Spinner sx={{ color: 'secondary' }} duration={750} size={28} />
@@ -201,7 +202,7 @@ const ChartWrapper = ({ data }) => {
         <TickLabels
           bottom
           values={ticks}
-          format={(d) => dateStrings.formatTick(Math.round(d))}
+          format={(d) => dateStrings.formatTick(Math.round(d)).toUpperCase()}
         />
         {typeof hovered === 'number' && circle && (
           <Box
@@ -217,7 +218,7 @@ const ChartWrapper = ({ data }) => {
                 fontFamily: 'mono',
                 letterSpacing: 'mono',
                 textTransform: 'uppercase',
-                fontSize: [1, 1, 1, 2],
+                fontSize: [0, 0, 0, 1],
                 color: 'secondary',
               }}
             >

--- a/components/sections/region/chart.js
+++ b/components/sections/region/chart.js
@@ -86,8 +86,9 @@ const ChartWrapper = ({ data }) => {
   const zoom = region?.properties?.zoom || 0
 
   // By default, use active dataset as primary dataset (reference for dateStrings and timescale)
-  let primaryDataset = datasets[activeDataset]
-  if (!primaryDataset) {
+  let primaryDataset = datasets ? datasets[activeDataset] : null
+
+  if (datasets && !primaryDataset) {
     // But fallback to first selected dataset if none is active
     const selectedName = Object.keys(datasets).find(
       (key) => datasets[key].selected
@@ -95,7 +96,10 @@ const ChartWrapper = ({ data }) => {
     primaryDataset = datasets[selectedName]
   }
 
-  const { dateStrings, timescale } = primaryDataset
+  // allow null to fix a bug whereby loading a dataset while viewing
+  // annual and then switching to monthly and deselecting caused a crash
+  const { dateStrings, timescale } = primaryDataset || {}
+
   const { timeRange, ticks, bands } = useMemo(() => {
     if (!dateStrings) {
       return {}

--- a/components/sections/time/sliders.js
+++ b/components/sections/time/sliders.js
@@ -13,6 +13,7 @@ const sx = {
   },
 }
 const TimeSlider = ({
+  scale,
   value,
   range,
   onChange,
@@ -22,11 +23,12 @@ const TimeSlider = ({
   debounce = false,
 }) => {
   const setUpdatingTime = useDatasetsStore((state) => state.setUpdatingTime)
+  const sliding = useDatasetsStore((state) => state.slidingTime)
+  const setSliding = useDatasetsStore((state) => state.setSlidingTime)
 
-  const [sliding, setSliding] = useState(false)
   const [sliderValue, setSliderValue] = useState(value)
   useEffect(() => {
-    if (!sliding && sliderValue !== value) {
+    if (!sliding[scale] && sliderValue !== value) {
       setSliderValue(value)
     }
   }, [sliding, sliderValue, value])
@@ -36,7 +38,7 @@ const TimeSlider = ({
       const updatedValue = parseFloat(e.target.value)
       setSliderValue(updatedValue)
 
-      if (!debounce || !sliding) {
+      if (!debounce || !sliding[scale]) {
         onChange(updatedValue)
       }
     },
@@ -44,13 +46,13 @@ const TimeSlider = ({
   )
 
   const handleMouseUp = useCallback(() => {
-    setSliding(false)
+    setSliding(scale, false)
     setUpdatingTime(false)
     if (debounce) onChange(sliderValue)
   }, [onChange, sliderValue, debounce])
 
   const handleMouseDown = useCallback(() => {
-    setSliding(true)
+    setSliding(scale, true)
     if (debounce) setUpdatingTime(true)
   }, [onChange, sliderValue, debounce])
 
@@ -76,8 +78,8 @@ const TimeSlider = ({
         <Box
           sx={{
             ...sx.label,
-            color: sliding ? 'primary' : 'secondary',
-            opacity: sliding || showValue ? 1 : 0,
+            color: sliding[scale] ? 'primary' : 'secondary',
+            opacity: sliding[scale] || showValue ? 1 : 0,
             transition: 'opacity 0.2s, color 0.2s',
           }}
         >
@@ -112,6 +114,7 @@ const Sliders = ({ dateStrings, historical = false }) => {
     <Flex sx={{ gap: [2, 2, 2, 3] }}>
       {timescale === 'day' && (
         <TimeSlider
+          scale='day'
           value={day}
           range={ranges.day}
           onChange={(value) => onChange({ day: value })}
@@ -125,6 +128,7 @@ const Sliders = ({ dateStrings, historical = false }) => {
       )}
       {['day', 'month'].includes(timescale) && (
         <TimeSlider
+          scale='month'
           value={month}
           range={ranges.month}
           onChange={(value) => onChange({ month: value })}
@@ -138,6 +142,7 @@ const Sliders = ({ dateStrings, historical = false }) => {
         />
       )}
       <TimeSlider
+        scale='year'
         value={year}
         range={ranges.year}
         onChange={(value) => onChange({ year: value })}


### PR DESCRIPTION
This PR fixes a few bugs and add a UI element to the regional chart.

- It fixes a bug whereby some datasets (e.g. `BCC-CSM2-MR raw SSP3-7.0`) would render with the wrong months (starting in DEC rather than JAN).
- It fixed some rare bugs I encountered where empty values for `datasets` or `primaryDataset` could crash the app when opening / closing the regional selector or adding / removing datasets, by more aggressively checking for these as potentially null.
- It removes pointer events on the spinner so that mouse hover and selection isn't interrupted within a small region of the middle of the chart.
- Matches style of label in upper right to axis labels.
- Matches uppercase style of x-axis label to the rest of the app
- Adds a vertical line "cursor" while dragging the time slider.
