### PR TITLE
small clean up

### DIFF
--- a/components/sections/display/display-section.js
+++ b/components/sections/display/display-section.js
@@ -13,7 +13,9 @@ const DisplaySection = ({ sx }) => {
       {active ? (
         <DisplayEditor sx={sx} />
       ) : (
-        <Box sx={sx.description}>Select a dataset to view properties.</Box>
+        <Box sx={sx.description}>
+          Select a dataset above to view properties.
+        </Box>
       )}
     </Box>
   )

--- a/components/sections/region/chart.js
+++ b/components/sections/region/chart.js
@@ -145,8 +145,9 @@ const ChartWrapper = ({ data }) => {
       const lineData = Object.keys(value)
         .map((time) => {
           const { avg, min, max } = getArrayData(value[time], lats, zoom)
-          range[0] = Math.min(range[0], ds.getDisplayValue(min, displayUnits))
-          range[1] = Math.max(range[1], ds.getDisplayValue(max, displayUnits))
+
+          range[0] = Math.min(range[0], ds.getDisplayValue(avg, displayUnits))
+          range[1] = Math.max(range[1], ds.getDisplayValue(avg, displayUnits))
 
           const activeTime = dateStrings.valuesToTime(
             ds.dateStrings.timeToValues(Number(time))
@@ -170,7 +171,7 @@ const ChartWrapper = ({ data }) => {
         color = activeColor
         width = 2
       } else if (name === hoveredDataset) {
-        color = 'primary'
+        color = activeColor
         width = 2
       }
       return {
@@ -198,7 +199,10 @@ const ChartWrapper = ({ data }) => {
       <LoadingSpinner opacity={loading ? 1 : 0} />
       <Chart
         x={timeRange}
-        y={range}
+        y={[
+          range[0] - 0.05 * (range[1] - range[0]),
+          range[1] + 0.05 * (range[1] - range[0]),
+        ]}
         padding={{ left: 35, right: 0, top: 0, bottom: 25 }}
       >
         <Grid horizontal />
@@ -214,7 +218,7 @@ const ChartWrapper = ({ data }) => {
             sx={{
               position: 'absolute',
               right: 0,
-              top: 0,
+              top: '-31px',
               mt: 0,
             }}
           >

--- a/components/use-routing.js
+++ b/components/use-routing.js
@@ -6,7 +6,7 @@ import { encodeJSON, decodeHex } from './utils'
 const validateQuery = (query, datasets) => {
   const {
     active,
-    t, // displayTime value
+    // t, // displayTime value
     filters: {
       t: scale,
       v: variable,
@@ -34,10 +34,10 @@ const validateQuery = (query, datasets) => {
     return false
   }
 
-  const [year, month, day] = t.split('-')
-  if (!year || !month || !day) {
-    return false
-  }
+  // const [year, month, day] = t.split('-')
+  // if (!year || !month || !day) {
+  //   return false
+  // }
 
   return true
 }
@@ -64,12 +64,12 @@ const useRouting = () => {
   const router = useRouter()
   const datasets = useDatasetsStore((state) => state.datasets)
   const active = useDatasetsStore((state) => state.active)
-  const displayTime = useDatasetsStore((state) => state.displayTime)
+  //const displayTime = useDatasetsStore((state) => state.displayTime)
   const variable = useDatasetsStore((state) => state.filters?.variable)
   const timescale = useDatasetsStore((state) => state.filters?.timescale)
   const experiment = useDatasetsStore((state) => state.filters?.experiment)
   const setActive = useDatasetsStore((state) => state.setActive)
-  const setDisplayTime = useDatasetsStore((state) => state.setDisplayTime)
+  //const setDisplayTime = useDatasetsStore((state) => state.setDisplayTime)
   const setFilters = useDatasetsStore((state) => state.setFilters)
 
   const initialized = !!datasets
@@ -83,8 +83,8 @@ const useRouting = () => {
       const decryptedQuery = { ...query, filters }
 
       if (validateQuery(decryptedQuery, datasets)) {
-        const { t } = decryptedQuery
-        const [year, month, day] = t.split('-')
+        // const { t } = decryptedQuery
+        // const [year, month, day] = t.split('-')
 
         const computedFilters = {
           variable: filters.v,
@@ -99,7 +99,7 @@ const useRouting = () => {
 
         datasets[decryptedQuery.active] && setActive(decryptedQuery.active)
         setFilters(computedFilters)
-        setDisplayTime({ year, month, day })
+        // setDisplayTime({ year, month, day })
       }
     }
   }, [initialized, router.isReady])
@@ -112,11 +112,11 @@ const useRouting = () => {
         ...(center ? { center } : {}),
         ...(zoom ? { zoom } : {}),
         ...(active ? { active } : {}),
-        ...(displayTime
-          ? {
-              t: `${displayTime.year}-${displayTime.month}-${displayTime.day}`,
-            }
-          : {}),
+        // ...(displayTime
+        //   ? {
+        //       t: `${displayTime.year}-${displayTime.month}-${displayTime.day}`,
+        //     }
+        //   : {}),
         f: getFilterHex({ variable, timescale, experiment }),
       }
 
@@ -124,7 +124,7 @@ const useRouting = () => {
         shallow: true,
       })
     }
-  }, [initialized, active, displayTime, variable, timescale, experiment])
+  }, [initialized, active, variable, timescale, experiment])
 }
 
 export default useRouting

--- a/components/use-routing.js
+++ b/components/use-routing.js
@@ -6,7 +6,7 @@ import { encodeJSON, decodeHex } from './utils'
 const validateQuery = (query, datasets) => {
   const {
     active,
-    // t, // displayTime value
+    t, // displayTime value
     filters: {
       t: scale,
       v: variable,
@@ -34,10 +34,10 @@ const validateQuery = (query, datasets) => {
     return false
   }
 
-  // const [year, month, day] = t.split('-')
-  // if (!year || !month || !day) {
-  //   return false
-  // }
+  const [year, month, day] = t.split('-')
+  if (!year || !month || !day) {
+    return false
+  }
 
   return true
 }
@@ -64,12 +64,12 @@ const useRouting = () => {
   const router = useRouter()
   const datasets = useDatasetsStore((state) => state.datasets)
   const active = useDatasetsStore((state) => state.active)
-  //const displayTime = useDatasetsStore((state) => state.displayTime)
+  const displayTime = useDatasetsStore((state) => state.displayTime)
   const variable = useDatasetsStore((state) => state.filters?.variable)
   const timescale = useDatasetsStore((state) => state.filters?.timescale)
   const experiment = useDatasetsStore((state) => state.filters?.experiment)
   const setActive = useDatasetsStore((state) => state.setActive)
-  //const setDisplayTime = useDatasetsStore((state) => state.setDisplayTime)
+  const setDisplayTime = useDatasetsStore((state) => state.setDisplayTime)
   const setFilters = useDatasetsStore((state) => state.setFilters)
 
   const initialized = !!datasets
@@ -83,8 +83,8 @@ const useRouting = () => {
       const decryptedQuery = { ...query, filters }
 
       if (validateQuery(decryptedQuery, datasets)) {
-        // const { t } = decryptedQuery
-        // const [year, month, day] = t.split('-')
+        const { t } = decryptedQuery
+        const [year, month, day] = t.split('-')
 
         const computedFilters = {
           variable: filters.v,
@@ -99,7 +99,7 @@ const useRouting = () => {
 
         datasets[decryptedQuery.active] && setActive(decryptedQuery.active)
         setFilters(computedFilters)
-        // setDisplayTime({ year, month, day })
+        setDisplayTime({ year, month, day })
       }
     }
   }, [initialized, router.isReady])
@@ -112,11 +112,11 @@ const useRouting = () => {
         ...(center ? { center } : {}),
         ...(zoom ? { zoom } : {}),
         ...(active ? { active } : {}),
-        // ...(displayTime
-        //   ? {
-        //       t: `${displayTime.year}-${displayTime.month}-${displayTime.day}`,
-        //     }
-        //   : {}),
+        ...(displayTime
+          ? {
+              t: `${displayTime.year}-${displayTime.month}-${displayTime.day}`,
+            }
+          : {}),
         f: getFilterHex({ variable, timescale, experiment }),
       }
 
@@ -124,7 +124,7 @@ const useRouting = () => {
         shallow: true,
       })
     }
-  }, [initialized, active, variable, timescale, experiment])
+  }, [initialized, active, displayTime, variable, timescale, experiment])
 }
 
 export default useRouting


### PR DESCRIPTION
This PR is a grab bag of UI clean up:

- Changed the line color in the region chart when hovering to match the color logic of hovering in the dataset display (makes it harder to distinguish from the selected dataset, but this was preferable to me to the confusing previous behavior)
- Set the range in the chart to the min/max of the time series (with a 5% buffer), rather than the mix/max of all pixels within the region
- Move the hovered datapoint info outside the chart (baseline aligned with "Regional data", to avoid intersections when there are multiple lines nearby)

