### PR TITLE
Track top-level clims per variable + timescale combination

### DIFF
--- a/components/dataset-raster.js
+++ b/components/dataset-raster.js
@@ -13,8 +13,13 @@ import { useRegionStore } from './region'
 
 const DatasetRaster = ({ name, index }) => {
   const active = useDatasetsStore((state) => state.active === name)
-  const { dateStrings, source, colormapName, clim, loaded, units } =
-    useDatasetsStore((state) => state.datasets[name], shallow)
+  const { dateStrings, source, colormapName, loaded, units } = useDatasetsStore(
+    (state) => state.datasets[name],
+    shallow
+  )
+  const clim = useDatasetsStore(
+    (state) => state.clims[state.filters.variable][state.filters.timescale]
+  )
   const setLoaded = useDatasetsStore((state) => state.setLoaded)
   const showRegionPicker = useRegionStore((state) => state.showRegionPicker)
   const setRegionData = useRegionStore((state) => state.setRegionData)

--- a/components/datasets/store.js
+++ b/components/datasets/store.js
@@ -8,7 +8,11 @@ import {
   getFiltersCallback,
   convertUnits,
 } from './utils'
-import { DEFAULT_DISPLAY_TIMES, DEFAULT_DISPLAY_UNITS } from './constants'
+import {
+  DEFAULT_CLIMS,
+  DEFAULT_DISPLAY_TIMES,
+  DEFAULT_DISPLAY_UNITS,
+} from './constants'
 
 const METHOD_ORDER = [
   'Raw',
@@ -56,7 +60,6 @@ const getInitialDatasets = (data, attrs) => {
         selected: false,
         loaded: false,
         colormapName: null,
-        clim: null,
 
         units: null,
         getDisplayValue: () => null,
@@ -91,11 +94,7 @@ export const useDatasetsStore = create((set, get) => ({
   active: null,
   hovered: null,
   filters: null,
-  clims: {
-    tasmax: { day: [-73, 27], month: [-73, 27], year: [-73, 27] },
-    tasmin: { day: [-73, 27], month: [-73, 27], year: [-73, 27] },
-    pr: { day: [0, 10], month: [0, 300], year: [0, 2000] },
-  },
+  clims: DEFAULT_CLIMS,
   displayTime: DEFAULT_DISPLAY_TIMES.HISTORICAL,
   displayUnits: DEFAULT_DISPLAY_UNITS.tasmax,
   updatingTime: false,
@@ -312,11 +311,11 @@ export const useDatasetsStore = create((set, get) => ({
   updateDatasetDisplay: (name, values) =>
     set(({ datasets, filters }) => {
       const invalidKey = Object.keys(values).find(
-        (k) => !['colormapName', 'clim'].includes(k)
+        (k) => !['colormapName'].includes(k)
       )
       if (invalidKey) {
         throw new Error(
-          `Unexpected display update. Invalid key: ${invalidKey}, must be one of 'colormapName', 'clim'`
+          `Unexpected display update. Invalid key: ${invalidKey}, must be equal to 'colormapName'`
         )
       }
 

--- a/components/datasets/store.js
+++ b/components/datasets/store.js
@@ -91,6 +91,11 @@ export const useDatasetsStore = create((set, get) => ({
   active: null,
   hovered: null,
   filters: null,
+  clims: {
+    tasmax: { day: [-73, 27], month: [-73, 27], year: [-73, 27] },
+    tasmin: { day: [-73, 27], month: [-73, 27], year: [-73, 27] },
+    pr: { day: [0, 10], month: [0, 300], year: [0, 2000] },
+  },
   displayTime: DEFAULT_DISPLAY_TIMES.HISTORICAL,
   displayUnits: DEFAULT_DISPLAY_UNITS.tasmax,
   updatingTime: false,
@@ -121,6 +126,16 @@ export const useDatasetsStore = create((set, get) => ({
   setUpdatingTime: (value) => set({ updatingTime: value }),
   setSlidingTime: (key, value) =>
     set((prev) => ({ slidingTime: { ...prev.slidingTime, [key]: value } })),
+  setClim: (value) =>
+    set((prev) => ({
+      clims: {
+        ...prev.clims,
+        [prev.filters.variable]: {
+          ...prev.clims[prev.filters.variable],
+          [prev.filters.timescale]: value,
+        },
+      },
+    })),
   loadDateStrings: async (name) => {
     const [date_str, time] = await Promise.all([
       new Promise((resolve) =>

--- a/components/datasets/utils.js
+++ b/components/datasets/utils.js
@@ -1,4 +1,4 @@
-import { DEFAULT_CLIMS, DEFAULT_COLORMAPS } from './constants'
+import { DEFAULT_COLORMAPS } from './constants'
 
 export const getFiltersCallback = (filters) => {
   return (d) => {
@@ -27,17 +27,13 @@ export const areSiblings = (d1, d2) => {
 }
 
 export const getDatasetDisplay = (dataset, filters, forceUpdate = false) => {
-  let { colormapName, clim } = dataset
+  let { colormapName } = dataset
 
   if (!colormapName || forceUpdate) {
     colormapName = DEFAULT_COLORMAPS[filters.variable]
   }
 
-  if (!clim || forceUpdate) {
-    clim = DEFAULT_CLIMS[filters.variable][filters.timescale]
-  }
-
-  return { colormapName, clim }
+  return { colormapName }
 }
 
 export const convertUnits = (value, from, to) => {

--- a/components/sections/display/display-editor.js
+++ b/components/sections/display/display-editor.js
@@ -3,7 +3,6 @@ import { Colorbar, Column, Row, Select } from '@carbonplan/components'
 import { colormaps, useThemedColormap } from '@carbonplan/colormaps'
 import shallow from 'zustand/shallow'
 
-import { formatValue } from '../../utils'
 import {
   convertUnits,
   useDatasetsStore,
@@ -31,20 +30,21 @@ const DisplayEditor = ({ sx }) => {
   const variable = useDatasetsStore((state) => state.filters.variable)
   const displayUnits = useDatasetsStore((state) => state.displayUnits)
   const setDisplayUnits = useDatasetsStore((state) => state.setDisplayUnits)
+  const clim = useDatasetsStore(
+    (state) => state.clims[state.filters.variable][state.filters.timescale]
+  )
+  const setClim = useDatasetsStore((state) => state.setClim)
 
   const updateDatasetDisplay = useDatasetsStore(
     (state) => state.updateDatasetDisplay
   )
-  const { colormapName, clim } = useDatasetsStore(
+  const { colormapName } = useDatasetsStore(
     (state) => state.datasets[name],
     shallow
   )
 
   const colormap = useThemedColormap(colormapName)
 
-  const setClim = (setter) => {
-    updateDatasetDisplay(name, { clim: setter(clim) })
-  }
   return (
     <>
       <Row columns={[6, 8, 4, 4]}>
@@ -125,7 +125,7 @@ const DisplayEditor = ({ sx }) => {
                 )
               }
               clim={clim}
-              setClim={setClim}
+              setClim={(setter) => setClim(setter(clim))}
               horizontal
               width={'100%'}
               sxClim={{ fontSize: [1, 1, 1, 2], mt: ['-1px'], pb: ['2px'] }}


### PR DESCRIPTION
Moves `clim` out of individual dataset objects and into top-level `clims` that maps `variable` and `timescale` to a unique clim reference. This means that the only dataset-specific display property is the `colormap`, which I've left in place for now along with the generic `getDatasetDisplay` logic.

Closes #58 