### PR TITLE
Improve chart and time performance

### DIFF
--- a/components/dataset-raster.js
+++ b/components/dataset-raster.js
@@ -21,7 +21,6 @@ const DatasetRaster = ({ name, index }) => {
     (state) => state.clims[state.filters.variable][state.filters.timescale]
   )
   const setLoaded = useDatasetsStore((state) => state.setLoaded)
-  const showRegionPicker = useRegionStore((state) => state.showRegionPicker)
   const setRegionData = useRegionStore((state) => state.setRegionData)
   const display = useDatasetsStore((state) => state.displayTime, shallow)
   const setDisplayTime = useDatasetsStore((state) => state.setDisplayTime)

--- a/components/dataset-raster.js
+++ b/components/dataset-raster.js
@@ -62,6 +62,7 @@ const DatasetRaster = ({ name, index }) => {
     }
     return dateStrings.getDisplayRange(display)
   }, [dateStrings, display])
+  const setData = useCallback((v) => setRegionData(name, v), [name])
 
   if (timeRange.length === 0) {
     return null
@@ -90,7 +91,7 @@ const DatasetRaster = ({ name, index }) => {
         setDatasetUnits(name, m.metadata[`0/${filters.variable}/.zattrs`].units)
       }
       regionOptions={{
-        setData: showRegionPicker ? (v) => setRegionData(name, v) : null,
+        setData,
         selector: { time: timeRange },
       }}
     />

--- a/components/header.js
+++ b/components/header.js
@@ -6,8 +6,10 @@ import {
   Header as HeaderComponent,
   Settings,
 } from '@carbonplan/components'
+import useRouting from './use-routing'
 
 const Header = ({ expanded, setExpanded }) => {
+  useRouting()
   return (
     <>
       <Meta

--- a/components/main.js
+++ b/components/main.js
@@ -17,7 +17,6 @@ import {
 import Map from './map'
 import { useRegionStore } from './region'
 import LoadingStates from './loading-states'
-import useRouting from './use-routing'
 import Methods from './methods.md'
 
 const sx = {
@@ -58,7 +57,6 @@ const sx = {
 }
 
 const Tool = () => {
-  useRouting()
   const index = useBreakpointIndex({ defaultIndex: 2 })
   const [expanded, setExpanded] = useState(index >= 2)
   const [expandedMethods, setExpandedMethods] = useState(false)

--- a/components/map.js
+++ b/components/map.js
@@ -38,19 +38,13 @@ const MapRouting = () => {
 
   useEffect(() => {
     if (center && zoom) {
-      const { center: prevCenter, zoom: prevZoom, ...rest } = router.query
-      router.replace(
-        {
-          pathname: '',
-          query: { center, zoom, ...rest },
-        },
-        null,
-        {
-          shallow: true,
-        }
-      )
+      const newUrl = new URL(window.location)
+      newUrl.searchParams.set('center', center)
+      newUrl.searchParams.set('zoom', zoom)
+
+      window.history.replaceState({}, '', newUrl)
     }
-  }, [router.isReady, center, zoom])
+  }, [center, zoom])
 
   return null
 }

--- a/components/map.js
+++ b/components/map.js
@@ -42,7 +42,11 @@ const MapRouting = () => {
       newUrl.searchParams.set('center', center)
       newUrl.searchParams.set('zoom', zoom)
 
-      window.history.replaceState({}, '', newUrl)
+      window.history.replaceState(
+        { ...window.history.state, as: newUrl.href, url: newUrl.href },
+        '',
+        newUrl
+      )
     }
   }, [center, zoom])
 

--- a/components/sections/region/chart.js
+++ b/components/sections/region/chart.js
@@ -119,6 +119,63 @@ const ChartWrapper = ({ data }) => {
     }
   }, [dateStrings, display])
 
+  const { lines, range, circle } = useMemo(() => {
+    let circle
+    let lines = []
+    const range = [Infinity, -Infinity]
+
+    if (!datasets || !dateStrings) {
+      return { circle, lines, range }
+    }
+
+    lines = data
+      .filter(([name, value, lats]) => value && lats && datasets[name].selected)
+      .map(([name, value, lats]) => {
+        const ds = datasets[name]
+
+        const lineData = Object.keys(value)
+          .map((time) => {
+            const { avg, min, max } = getArrayData(value[time], lats, zoom)
+            range[0] = Math.min(range[0], ds.getDisplayValue(min, displayUnits))
+            range[1] = Math.max(range[1], ds.getDisplayValue(max, displayUnits))
+
+            const activeTime = dateStrings.valuesToTime(
+              ds.dateStrings.timeToValues(Number(time))
+            )
+
+            const convertedAvg = ds.getDisplayValue(avg, displayUnits)
+
+            if (name === activeDataset && hovered === activeTime) {
+              circle = [activeTime, convertedAvg]
+            }
+
+            return [activeTime, convertedAvg]
+          })
+          .filter((p) => typeof p[0] === 'number')
+
+        let color = 'secondary'
+        let width = 1.5
+        const activeColor = COLORMAP_COLORS[ds.colormapName]
+
+        if (name === activeDataset) {
+          color = activeColor
+          width = 2
+        } else if (name === hoveredDataset) {
+          color = 'primary'
+          width = 2
+        }
+        return {
+          key: name,
+          circle,
+          color,
+          width,
+          lineData,
+        }
+      }, [])
+
+    return { lines, range, circle }
+  }, [datasets, dateStrings, data])
+
   // We cannot render domain before dateStrings have been loaded, so return generic loading text
   if (!datasets || !dateStrings) {
     return (
@@ -133,55 +190,6 @@ const ChartWrapper = ({ data }) => {
       </Box>
     )
   }
-
-  let circle
-  const range = [Infinity, -Infinity]
-
-  const lines = data
-    .filter(([name, value, lats]) => value && lats && datasets[name].selected)
-    .map(([name, value, lats]) => {
-      const ds = datasets[name]
-
-      const lineData = Object.keys(value)
-        .map((time) => {
-          const { avg, min, max } = getArrayData(value[time], lats, zoom)
-
-          range[0] = Math.min(range[0], ds.getDisplayValue(avg, displayUnits))
-          range[1] = Math.max(range[1], ds.getDisplayValue(avg, displayUnits))
-
-          const activeTime = dateStrings.valuesToTime(
-            ds.dateStrings.timeToValues(Number(time))
-          )
-
-          const convertedAvg = ds.getDisplayValue(avg, displayUnits)
-
-          if (name === activeDataset && hovered === activeTime) {
-            circle = [activeTime, convertedAvg]
-          }
-
-          return [activeTime, convertedAvg]
-        })
-        .filter((p) => typeof p[0] === 'number')
-
-      let color = 'secondary'
-      let width = 1.5
-      const activeColor = COLORMAP_COLORS[ds.colormapName]
-
-      if (name === activeDataset) {
-        color = activeColor
-        width = 2
-      } else if (name === hoveredDataset) {
-        color = activeColor
-        width = 2
-      }
-      return {
-        key: name,
-        circle,
-        color,
-        width,
-        lineData,
-      }
-    }, [])
 
   const loading = data.some(([name, value]) => !value)
 

--- a/components/sections/region/chart.js
+++ b/components/sections/region/chart.js
@@ -157,11 +157,8 @@ const ChartWrapper = ({ data }) => {
         let width = 1.5
         const activeColor = COLORMAP_COLORS[ds.colormapName]
 
-        if (name === activeDataset) {
+        if (name === activeDataset || name === hoveredDataset) {
           color = activeColor
-          width = 2
-        } else if (name === hoveredDataset) {
-          color = 'primary'
           width = 2
         }
         return {
@@ -174,7 +171,7 @@ const ChartWrapper = ({ data }) => {
       }, [])
 
     return { lines, range, circle }
-  }, [datasets, dateStrings, data])
+  }, [datasets, dateStrings, data, hovered, activeDataset, hoveredDataset])
 
   // We cannot render domain before dateStrings have been loaded, so return generic loading text
   if (!datasets || !dateStrings) {

--- a/components/use-routing.js
+++ b/components/use-routing.js
@@ -130,7 +130,11 @@ const useRouting = () => {
         getFilterHex({ variable, timescale, experiment })
       )
 
-      window.history.replaceState({}, '', newUrl)
+      window.history.replaceState(
+        { ...window.history.state, as: newUrl.href, url: newUrl.href },
+        '',
+        newUrl
+      )
     }
   }, [initialized, active, displayTime, variable, timescale, experiment])
 }

--- a/components/use-routing.js
+++ b/components/use-routing.js
@@ -37,9 +37,11 @@ const validateQuery = (query, datasets) => {
     return false
   }
 
-  const [year, month, day] = t.split('-')
-  if (!year || !month || !day) {
-    return false
+  if (t) {
+    const [year, month, day] = t.split('-')
+    if (!year || !month || !day) {
+      return false
+    }
   }
 
   return true
@@ -86,9 +88,6 @@ const useRouting = () => {
       const decryptedQuery = { ...query, filters }
 
       if (validateQuery(decryptedQuery, datasets)) {
-        const { t } = decryptedQuery
-        const [year, month, day] = t.split('-')
-
         const computedFilters = {
           variable: filters.v,
           timescale: filters.t,
@@ -102,7 +101,11 @@ const useRouting = () => {
 
         datasets[decryptedQuery.active] && setActive(decryptedQuery.active)
         setFilters(computedFilters)
-        setDisplayTime({ year, month, day })
+        const { t } = decryptedQuery
+        if (t) {
+          const [year, month, day] = t.split('-')
+          setDisplayTime({ year, month, day })
+        }
       } else {
         setActive(DEFAULT_ACTIVE)
       }

--- a/components/use-routing.js
+++ b/components/use-routing.js
@@ -112,26 +112,7 @@ const useRouting = () => {
   // Update the URL when the active dataset, display time, or filters change.
   useEffect(() => {
     if (initialized) {
-      const { center, zoom } = router.query
-      const query = {
-        ...(center ? { center } : {}),
-        ...(zoom ? { zoom } : {}),
-        ...(active ? { active } : {}),
-        ...(displayTime
-          ? {
-              t: `${displayTime.year}-${displayTime.month}-${displayTime.day}`,
-            }
-          : {}),
-        f: getFilterHex({ variable, timescale, experiment }),
-      }
-
       const newUrl = new URL(window.location)
-      if (center) {
-        newUrl.searchParams.set('center', center)
-      }
-      if (zoom) {
-        newUrl.searchParams.set('zoom', zoom)
-      }
       if (active) {
         newUrl.searchParams.set('active', active)
       }

--- a/components/use-routing.js
+++ b/components/use-routing.js
@@ -9,7 +9,7 @@ const DEFAULT_ACTIVE =
 const validateQuery = (query, datasets) => {
   const {
     active,
-    // t, // displayTime value
+    t, // displayTime value
     filters: {
       t: scale,
       v: variable,
@@ -37,10 +37,10 @@ const validateQuery = (query, datasets) => {
     return false
   }
 
-  // const [year, month, day] = t.split('-')
-  // if (!year || !month || !day) {
-  //   return false
-  // }
+  const [year, month, day] = t.split('-')
+  if (!year || !month || !day) {
+    return false
+  }
 
   return true
 }
@@ -67,12 +67,12 @@ const useRouting = () => {
   const router = useRouter()
   const datasets = useDatasetsStore((state) => state.datasets)
   const active = useDatasetsStore((state) => state.active)
-  //const displayTime = useDatasetsStore((state) => state.displayTime)
+  const displayTime = useDatasetsStore((state) => state.displayTime)
   const variable = useDatasetsStore((state) => state.filters?.variable)
   const timescale = useDatasetsStore((state) => state.filters?.timescale)
   const experiment = useDatasetsStore((state) => state.filters?.experiment)
   const setActive = useDatasetsStore((state) => state.setActive)
-  //const setDisplayTime = useDatasetsStore((state) => state.setDisplayTime)
+  const setDisplayTime = useDatasetsStore((state) => state.setDisplayTime)
   const setFilters = useDatasetsStore((state) => state.setFilters)
 
   const initialized = !!datasets
@@ -86,8 +86,8 @@ const useRouting = () => {
       const decryptedQuery = { ...query, filters }
 
       if (validateQuery(decryptedQuery, datasets)) {
-        // const { t } = decryptedQuery
-        // const [year, month, day] = t.split('-')
+        const { t } = decryptedQuery
+        const [year, month, day] = t.split('-')
 
         const computedFilters = {
           variable: filters.v,
@@ -102,7 +102,7 @@ const useRouting = () => {
 
         datasets[decryptedQuery.active] && setActive(decryptedQuery.active)
         setFilters(computedFilters)
-        // setDisplayTime({ year, month, day })
+        setDisplayTime({ year, month, day })
       } else {
         setActive(DEFAULT_ACTIVE)
       }
@@ -117,19 +117,38 @@ const useRouting = () => {
         ...(center ? { center } : {}),
         ...(zoom ? { zoom } : {}),
         ...(active ? { active } : {}),
-        // ...(displayTime
-        //   ? {
-        //       t: `${displayTime.year}-${displayTime.month}-${displayTime.day}`,
-        //     }
-        //   : {}),
+        ...(displayTime
+          ? {
+              t: `${displayTime.year}-${displayTime.month}-${displayTime.day}`,
+            }
+          : {}),
         f: getFilterHex({ variable, timescale, experiment }),
       }
 
-      router.replace({ pathname: '', query }, null, {
-        shallow: true,
-      })
+      const newUrl = new URL(window.location)
+      if (center) {
+        newUrl.searchParams.set('center', center)
+      }
+      if (zoom) {
+        newUrl.searchParams.set('zoom', zoom)
+      }
+      if (active) {
+        newUrl.searchParams.set('active', active)
+      }
+      if (displayTime) {
+        newUrl.searchParams.set(
+          't',
+          `${displayTime.year}-${displayTime.month}-${displayTime.day}`
+        )
+      }
+      newUrl.searchParams.set(
+        'f',
+        getFilterHex({ variable, timescale, experiment })
+      )
+
+      window.history.replaceState({}, '', newUrl)
     }
-  }, [initialized, active, variable, timescale, experiment])
+  }, [initialized, active, displayTime, variable, timescale, experiment])
 }
 
 export default useRouting

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@carbonplan/charts": "^2.2.0",
         "@carbonplan/colormaps": "^3.0.0",
-        "@carbonplan/components": "^11.5.2",
+        "@carbonplan/components": "^11.6.1",
         "@carbonplan/icons": "^1.1.1",
         "@carbonplan/layouts": "^1.5.0",
         "@carbonplan/maps": "^2.2.1",
@@ -408,9 +408,9 @@
       }
     },
     "node_modules/@carbonplan/components": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-11.5.2.tgz",
-      "integrity": "sha512-/RvQOAA1dfuvoF3tor7E9zJcbyS9Z+FF9E88rjVYM85Hbo5PmeqylQlc1Hj5h4q8QqtNlHDc/U4jWarHj8hCpQ==",
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-11.6.1.tgz",
+      "integrity": "sha512-1kk0l8K71o9U7KmQVVE2utLSTGLe7e06pOL7p6mv0MqB77ZzbC7LX4HAFe65uCT8vp/cgs3fwRvvJGxKvAnqUQ==",
       "dependencies": {
         "@carbonplan/emoji": "^1.0.0",
         "@carbonplan/icons": "^1.0.0",
@@ -5711,9 +5711,9 @@
       }
     },
     "@carbonplan/components": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-11.5.2.tgz",
-      "integrity": "sha512-/RvQOAA1dfuvoF3tor7E9zJcbyS9Z+FF9E88rjVYM85Hbo5PmeqylQlc1Hj5h4q8QqtNlHDc/U4jWarHj8hCpQ==",
+      "version": "11.6.1",
+      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-11.6.1.tgz",
+      "integrity": "sha512-1kk0l8K71o9U7KmQVVE2utLSTGLe7e06pOL7p6mv0MqB77ZzbC7LX4HAFe65uCT8vp/cgs3fwRvvJGxKvAnqUQ==",
       "requires": {
         "@carbonplan/emoji": "^1.0.0",
         "@carbonplan/icons": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@carbonplan/components": "^11.5.2",
         "@carbonplan/icons": "^1.1.1",
         "@carbonplan/layouts": "^1.5.0",
-        "@carbonplan/maps": "^2.1.1",
+        "@carbonplan/maps": "^2.2.1",
         "@carbonplan/theme": "^7.0.0",
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
@@ -459,9 +459,9 @@
       }
     },
     "node_modules/@carbonplan/maps": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@carbonplan/maps/-/maps-2.1.1.tgz",
-      "integrity": "sha512-lnlfP8lzA4Ti9we3uhl2iWiaioQD1sFTLB4acLustnKBTfnBGltE6VojCYpKBdESAc19QGwMUWcWnnaXvzPQUw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@carbonplan/maps/-/maps-2.2.1.tgz",
+      "integrity": "sha512-c/ZqPHCL/6O9FP9sghDIfG8SPaWm3ZBhqM5hWr+wk4O8vEhqeKAYK4DMzsno4bikLPtsBjTwoNmZyBGF7fRbQA==",
       "dependencies": {
         "@turf/turf": "^6.5.0",
         "d3-array": "^2.12.1",
@@ -5741,9 +5741,9 @@
       }
     },
     "@carbonplan/maps": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@carbonplan/maps/-/maps-2.1.1.tgz",
-      "integrity": "sha512-lnlfP8lzA4Ti9we3uhl2iWiaioQD1sFTLB4acLustnKBTfnBGltE6VojCYpKBdESAc19QGwMUWcWnnaXvzPQUw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@carbonplan/maps/-/maps-2.2.1.tgz",
+      "integrity": "sha512-c/ZqPHCL/6O9FP9sghDIfG8SPaWm3ZBhqM5hWr+wk4O8vEhqeKAYK4DMzsno4bikLPtsBjTwoNmZyBGF7fRbQA==",
       "requires": {
         "@turf/turf": "^6.5.0",
         "d3-array": "^2.12.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@carbonplan/charts": "^2.2.0",
     "@carbonplan/colormaps": "^3.0.0",
-    "@carbonplan/components": "^11.5.2",
+    "@carbonplan/components": "^11.6.1",
     "@carbonplan/icons": "^1.1.1",
     "@carbonplan/layouts": "^1.5.0",
     "@carbonplan/maps": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@carbonplan/components": "^11.5.2",
     "@carbonplan/icons": "^1.1.1",
     "@carbonplan/layouts": "^1.5.0",
-    "@carbonplan/maps": "^2.1.1",
+    "@carbonplan/maps": "^2.2.1",
     "@carbonplan/theme": "^7.0.0",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -7,7 +7,7 @@ class MyDocument extends Document {
     return (
       <Html lang='en' className='no-focus-outline'>
         <Head>
-          <Tracking />
+          <Tracking id={process.env.GA_TRACKING_ID} />
         </Head>
         <body>
           <InitializeColorMode />


### PR DESCRIPTION
Along with https://github.com/carbonplan/maps/pull/78, closes #57 

- Avoid redefining `regionOptions.setData`
- Memoize chart line generation

Also closes #56

- Uses `window.history.replaceState` instead of the `next/router` `replace` to avoid re-rendering (see https://github.com/vercel/next.js/discussions/18072), which caused significant slowdowns